### PR TITLE
docs: add Road to v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ The installer supports incremental adoption:
 
 For a walkthrough, see `docs/adoption.md`.
 
+## Road to v1.0.0
+
+This repository is intentionally iterating in `0.x` while we collect community feedback and harden the installer and docs.
+
+Tracking issue: #3
+
+Current focus areas:
+
+- Installer stability (presets, conflicts, uninstall manifest)
+- First-time user onboarding (feedback-driven improvements)
+- Documentation accuracy and third-party attribution hygiene
+- CI + security gates that keep `main` safe by default
+
 ## What You Get
 
 ### Multi-Agent Deliberation


### PR DESCRIPTION
## Summary
Add a short, visible Road to v1.0.0 section to set expectations for 0.x iteration and point contributors to the tracking issue.

## Changes
- Update `README.md` with a `Road to v1.0.0` section
- Link to the v1.0.0 criteria issue (#3)

## Verification
- Docs-only change
