### PR TITLE
docs: outline contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,21 @@ Thanks for contributing.
 - Include before/after behavior when relevant.
 - Update docs when behavior changes (especially `README.md` and `docs/`).
 
+## Ways to Contribute
+
+- **Onboarding feedback:** if you ran the installer for the first time, report what was confusing or brittle.
+- **Docs:** clarify adoption paths, presets/flags, or third-party attribution.
+- **Skills/agents/commands:** fix incorrect guidance, tighten triggers, or add concise examples.
+- **Installer hardening:** improve conflict handling, manifest uninstall behavior, and dry-run correctness.
+
+## Workflow
+
+- Create a branch from `main`.
+- Open a pull request.
+- Keep changes focused (small PRs merge faster).
+
+Note: `main` is protected. Direct pushes are blocked and merges require CI to pass.
+
 ## Local Validation
 
 Run these checks before opening a PR:
@@ -34,7 +49,17 @@ bash -n scripts/*.sh
 # JSON
 python3 -m json.tool settings.json >/dev/null
 python3 -m json.tool hooks.json >/dev/null
+
+# Installer smoke test (safe, isolated)
+CLAUDE_DIR="/tmp/claude-test" ./install.sh --preset skills --conflict-policy fail
+CLAUDE_DIR="/tmp/claude-test" ./install.sh --uninstall
 ```
+
+## Documentation Expectations
+
+- Prefer minimal-diff edits.
+- Keep paths and commands copy/pasteable.
+- Avoid introducing non-ASCII characters unless the file already uses them.
 
 ## Third-Party Content
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ Current focus areas:
 - Documentation accuracy and third-party attribution hygiene
 - CI + security gates that keep `main` safe by default
 
+## Contributing
+
+Contributions are welcome, especially anything that improves first-time adoption.
+
+- Start here: `CONTRIBUTING.md`
+- Share first-time setup feedback: open an issue using the “Onboarding feedback” template
+- Propose changes: open a PR (direct pushes to `main` are blocked by branch protection)
+- Security issues: see `SECURITY.md`
+
 ## What You Get
 
 ### Multi-Agent Deliberation


### PR DESCRIPTION
## Summary
Make contributing expectations easier to discover and keep PRs high-signal.

## Changes
- Add a short `Contributing` section to `README.md`
- Expand `CONTRIBUTING.md` with ways to contribute, workflow, and a safe installer smoke test

## Verification
- Local shell + JSON validation checks passed
