### PR TITLE
feat: add dbt skill with progressive disclosure

### DIFF
--- a/skills/dbt-skill/README.md
+++ b/skills/dbt-skill/README.md
@@ -1,0 +1,140 @@
+# dbt Skill for Claude
+
+[![Claude Skill](https://img.shields.io/badge/Claude-Skill-5865F2)](https://docs.claude.ai/docs/agent-skills)
+[![dbt](https://img.shields.io/badge/dbt-1.5+-FF694B)](https://www.getdbt.com/)
+[![Snowflake](https://img.shields.io/badge/Snowflake-supported-29B5E8)](https://www.snowflake.com/)
+[![BigQuery](https://img.shields.io/badge/BigQuery-supported-4285F4)](https://cloud.google.com/bigquery)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+
+Comprehensive dbt (data build tool) skill for Claude Code. Get instant guidance on project structure, modeling methodology, testing strategies, CI/CD workflows, and production-ready analytics engineering.
+
+## What This Skill Provides
+
+**Project Structure & Modeling**
+- Medallion + Kimball methodology (staging → intermediate → marts)
+- Naming conventions and SQL style guide
+- Materialization decision matrices
+- Source configuration with freshness monitoring
+
+**Testing & Quality**
+- Testing pyramid: schema, generic, singular, and unit tests
+- dbt-expectations and dbt-utils integration
+- Layer-specific testing strategies
+- Data quality metrics and observability
+
+**CI/CD & Deployment**
+- GitHub Actions workflows (Snowflake + BigQuery)
+- Slim CI with `state:modified+`
+- Blue/green deployment patterns
+- SQLFluff linting integration
+
+**Performance & Scale**
+- Incremental strategies: microbatch (1.9+), merge, delete+insert, insert_overwrite
+- Snowflake tuning: cluster keys, transient tables, Dynamic Tables
+- BigQuery tuning: partitioning, clustering, slot management
+- Cost monitoring and optimization
+
+**Advanced Capabilities**
+- Jinja macros and warehouse-adaptive patterns
+- Essential packages (dbt-utils, dbt-expectations, Elementary)
+- Semantic Layer and MetricFlow
+- Model contracts, versions, and access controls
+- dbt Mesh for multi-project architectures
+
+## Installation
+
+### Claude Code
+
+```bash
+# Clone to Claude skills directory
+git clone https://github.com/danielsong/dbt-skill ~/.claude/skills/dbt-skill
+```
+
+### Verify Installation
+
+After installation, try:
+```
+"Create a dbt project with staging and marts layers for a Snowflake warehouse"
+```
+
+Claude will automatically use the skill when working with dbt.
+
+## Quick Start Examples
+
+**Create a project structure:**
+> "Set up a dbt project with staging and marts layers for our Stripe and Shopify data"
+
+**Choose a materialization:**
+> "Should I use incremental or table materialization for my 500M row events table?"
+
+**Write tests:**
+> "Add comprehensive tests to my fct_orders model"
+
+**Set up CI/CD:**
+> "Create a GitHub Actions workflow for dbt with Slim CI on Snowflake"
+
+**Optimize performance:**
+> "My incremental model is slow on BigQuery — help me optimize it"
+
+## Skill Structure
+
+The skill uses **progressive disclosure** — the core file covers essentials, reference files provide depth:
+
+```
+skills/dbt-skill/
+├── SKILL.md                              # Core skill — project structure, modeling,
+│                                         #   conventions, materializations, commands
+└── references/
+    ├── testing-quality.md                # 1️⃣  Testing & Quality Strategy
+    ├── ci-cd-deployment.md               # 2️⃣  CI/CD & Deployment
+    ├── jinja-macros-packages.md          # 3️⃣  Jinja, Macros & Packages
+    ├── incremental-performance.md        # 4️⃣  Incremental Models & Performance
+    ├── data-quality-observability.md     # 5️⃣  Data Quality & Observability
+    └── semantic-layer-governance.md      # 6️⃣  Semantic Layer & Governance
+```
+
+### Learning Path
+
+The reference files follow a deliberate progression:
+
+1. **Testing & Quality** — Foundation: validate your models work correctly
+2. **CI/CD & Deployment** — Feedback loop: automate build, test, deploy
+3. **Jinja, Macros & Packages** — DRY: reduce duplication, leverage ecosystem
+4. **Incremental Models & Performance** — Scale: handle growing data volumes
+5. **Data Quality & Observability** — Production: monitor and alert on issues
+6. **Semantic Layer & Governance** — Enterprise: centralize metrics and access control
+
+## Warehouse Support
+
+| Feature | Snowflake | BigQuery |
+|---------|-----------|----------|
+| All materializations | Yes | Yes |
+| Incremental strategies | merge, delete+insert, microbatch, append | merge, insert_overwrite, microbatch, append |
+| Partitioning guidance | Automatic micro-partitions | Manual partition_by config |
+| Clustering guidance | Yes | Yes |
+| CI/CD templates | Yes | Yes |
+| Cost optimization | Credits-based | Bytes-scanned / Slots |
+| Dynamic Tables | Yes | N/A |
+
+## Requirements
+
+- **Claude Code** or other Claude environment supporting skills
+- **dbt Core** 1.5+ or **dbt Cloud**
+- **Snowflake** or **BigQuery** warehouse (primary targets)
+- Other warehouses (Redshift, Databricks, Postgres) work with dbt but receive less specific guidance in this skill
+
+## Contributing
+
+Contributions welcome! When submitting changes:
+
+1. Follow the imperative voice style ("Use X", not "You should consider X")
+2. Include both Snowflake and BigQuery examples where relevant
+3. Use practical e-commerce domain examples (orders, payments, customers)
+4. Keep the core SKILL.md under ~500 lines
+5. Reference files should be self-contained with TOC and back-links
+
+## License
+
+Apache 2.0 — see [LICENSE](../../LICENSE) for full terms.
+
+**Copyright 2026 Daniel Song**

--- a/skills/dbt-skill/SKILL.md
+++ b/skills/dbt-skill/SKILL.md
@@ -1,0 +1,523 @@
+---
+name: dbt-skill
+description: Use when working with dbt (data build tool) - creating models, writing tests, CI/CD pipelines, materializations, sources, staging/intermediate/marts layers, Snowflake/BigQuery warehouse configuration, incremental strategies, Jinja macros, data quality, semantic layer, or making analytics engineering decisions
+license: Apache-2.0
+metadata:
+  author: Daniel Song
+  version: 1.0.0
+---
+
+# dbt Skill for Claude
+
+Comprehensive dbt guidance covering project structure, modeling methodology, testing, CI/CD, and production patterns. Targets Snowflake and BigQuery as primary warehouses. Beginner-friendly with progressive scaling toward advanced capabilities.
+
+## When to Use This Skill
+
+**Activate this skill when:**
+- Creating new dbt projects or adding models to existing ones
+- Choosing materializations (view, table, incremental, ephemeral, snapshot)
+- Structuring staging, intermediate, and marts layers
+- Setting up testing strategies (schema, generic, singular, unit)
+- Implementing CI/CD pipelines for dbt
+- Configuring sources and freshness monitoring
+- Writing Jinja macros or installing dbt packages
+- Reviewing or refactoring existing dbt projects
+- Making analytics engineering architecture decisions
+
+**Don't use this skill for:**
+- Basic SQL syntax questions (Claude knows this)
+- Warehouse administration (user management, networking, billing)
+- Raw data pipeline configuration (Fivetran, Airbyte, Stitch)
+- BI tool configuration (Looker, Tableau, Power BI)
+
+## Core Principles
+
+### 1. DRY via ref() and source()
+
+Every model references upstream dependencies through `ref()` or `source()` — never hardcoded table names.
+
+### 2. Single Source of Truth
+
+Each concept is defined once. Staging models are the single entry point for raw data. Marts are the single interface for consumers.
+
+### 3. Idempotent Transformations
+
+Running `dbt run` twice produces the same result. Models are deterministic and reproducible.
+
+### 4. Test Everything
+
+Tests are not optional. Every model has at minimum a primary key uniqueness and not-null test.
+
+### 5. Progressive Complexity
+
+Start simple (views and tables), add complexity only when data volume or business requirements demand it.
+
+## Project Structure
+
+```
+dbt_project/
+├── dbt_project.yml              # Project configuration
+├── packages.yml                 # Package dependencies
+├── profiles.yml                 # Connection profiles (local only, not committed)
+├── models/
+│   ├── staging/                 # 1:1 with source tables
+│   │   ├── stripe/
+│   │   │   ├── _stripe__models.yml
+│   │   │   ├── _stripe__sources.yml
+│   │   │   ├── stg_stripe__payments.sql
+│   │   │   └── stg_stripe__customers.sql
+│   │   └── shopify/
+│   │       ├── _shopify__models.yml
+│   │       ├── _shopify__sources.yml
+│   │       └── stg_shopify__orders.sql
+│   ├── intermediate/            # Business logic joins and transformations
+│   │   ├── finance/
+│   │   │   ├── _int_finance__models.yml
+│   │   │   └── int_payments_pivoted.sql
+│   │   └── marketing/
+│   │       └── int_web_sessions_sessionized.sql
+│   └── marts/                   # Business-facing tables
+│       ├── finance/
+│       │   ├── _finance__models.yml
+│       │   ├── fct_orders.sql
+│       │   └── dim_customers.sql
+│       └── marketing/
+│           ├── _marketing__models.yml
+│           └── fct_web_sessions.sql
+├── macros/                      # Reusable Jinja macros
+├── tests/                       # Singular and generic tests
+│   └── generic/                 # Custom generic tests
+├── seeds/                       # CSV reference data
+├── snapshots/                   # SCD Type 2 snapshots
+└── analyses/                    # Ad-hoc analytical queries
+```
+
+### dbt_project.yml Template
+
+```yaml
+name: 'my_project'
+version: '1.0.0'
+config-version: 2
+
+profile: 'my_project'
+
+model-paths: ["models"]
+analysis-paths: ["analyses"]
+test-paths: ["tests"]
+seed-paths: ["seeds"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+clean-targets: ["target", "dbt_packages"]
+
+models:
+  my_project:
+    staging:
+      +materialized: view           # Lightweight, always fresh
+    intermediate:
+      +materialized: ephemeral      # No warehouse cost, inlined as CTEs
+    marts:
+      +materialized: table          # Fast reads for BI tools
+```
+
+## Modeling Methodology — Medallion + Kimball
+
+### Layer Decision Matrix
+
+| Layer | Materialization | Purpose | Naming | Tests |
+|-------|----------------|---------|--------|-------|
+| **Staging** | `view` | Clean and rename raw data, 1:1 with source | `stg_<source>__<entity>` | not_null, unique on PK |
+| **Intermediate** | `ephemeral` | Business logic, joins, pivots | `int_<entity>_<verb>ed` | Tested via downstream |
+| **Marts** | `table` / `incremental` | Business-facing facts and dimensions | `fct_<entity>`, `dim_<entity>` | Full test coverage |
+| **Reports** | `table` | Pre-aggregated for specific dashboards | `rpt_<entity>` | Acceptance tests |
+
+### Layer Flow
+
+```
+Raw Data (sources)
+    ↓
+Staging (stg_) ── view ── clean, rename, cast, 1:1
+    ↓
+Intermediate (int_) ── ephemeral ── join, pivot, business logic
+    ↓
+Marts (fct_, dim_) ── table/incremental ── business entities
+    ↓
+BI Tools / Consumers
+```
+
+### Staging Model Pattern
+
+```sql
+-- stg_stripe__payments.sql
+with source as (
+    select * from {{ source('stripe', 'payments') }}
+),
+
+renamed as (
+    select
+        -- primary key
+        id as payment_id,
+
+        -- foreign keys
+        order_id,
+        customer_id,
+
+        -- properties
+        lower(payment_method) as payment_method,
+        status as payment_status,
+
+        -- numerics
+        amount / 100.0 as amount_dollars,
+
+        -- timestamps
+        created_at,
+        updated_at
+
+    from source
+)
+
+select * from renamed
+```
+
+### Intermediate Model Pattern
+
+```sql
+-- int_payments_pivoted.sql
+with payments as (
+    select * from {{ ref('stg_stripe__payments') }}
+),
+
+pivoted as (
+    select
+        order_id,
+        sum(case when payment_method = 'credit_card' then amount_dollars else 0 end) as credit_card_amount,
+        sum(case when payment_method = 'bank_transfer' then amount_dollars else 0 end) as bank_transfer_amount,
+        sum(amount_dollars) as total_amount
+    from payments
+    where payment_status = 'completed'
+    group by order_id
+)
+
+select * from pivoted
+```
+
+### Marts Model Pattern
+
+```sql
+-- fct_orders.sql
+with orders as (
+    select * from {{ ref('stg_shopify__orders') }}
+),
+
+payments as (
+    select * from {{ ref('int_payments_pivoted') }}
+),
+
+final as (
+    select
+        orders.order_id,
+        orders.customer_id,
+        orders.order_date,
+        orders.order_status,
+        payments.credit_card_amount,
+        payments.bank_transfer_amount,
+        payments.total_amount
+    from orders
+    left join payments on orders.order_id = payments.order_id
+)
+
+select * from final
+```
+
+## Model Naming Conventions
+
+### Models
+
+| Layer | Pattern | Example |
+|-------|---------|---------|
+| Staging | `stg_<source>__<entity>` | `stg_stripe__payments` |
+| Intermediate | `int_<entity>_<verb>ed` | `int_payments_pivoted` |
+| Facts | `fct_<entity>` | `fct_orders` |
+| Dimensions | `dim_<entity>` | `dim_customers` |
+| Reports | `rpt_<entity>` | `rpt_monthly_revenue` |
+
+### YAML Files
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| Model config | `_<layer>__models.yml` | `_stripe__models.yml` |
+| Sources | `_<layer>__sources.yml` | `_stripe__sources.yml` |
+
+Use the leading underscore to sort config files above model files in the directory listing.
+
+## SQL Style Guide
+
+### Rules
+
+1. **Leading commas** — easier to comment out lines, cleaner diffs
+2. **Lowercase keywords** — `select`, not `SELECT`
+3. **CTEs over subqueries** — always use `with` blocks
+4. **Explicit columns** — never `select *` in marts (acceptable in staging `with source`)
+5. **Final CTE** — name the last CTE `final` for consistency
+6. **4-space indentation** — align for readability
+7. **One column per line** — in select statements
+
+### Complete Example
+
+```sql
+with source as (
+    select * from {{ source('shopify', 'orders') }}
+),
+
+renamed as (
+    select
+        id as order_id,
+        user_id as customer_id,
+        lower(status) as order_status,
+        created_at as order_date,
+        updated_at
+    from source
+),
+
+final as (
+    select
+        order_id,
+        customer_id,
+        order_status,
+        order_date,
+        updated_at
+    from renamed
+    where order_status is not null
+)
+
+select * from final
+```
+
+## Materialization Decision Matrix
+
+| Situation | Materialization | Why |
+|-----------|----------------|-----|
+| Staging models | `view` | Always fresh, minimal storage cost |
+| Intermediate logic | `ephemeral` | Zero cost, inlined as CTE |
+| Marts < 100M rows | `table` | Simple, fast reads |
+| Marts > 100M rows | `incremental` | Only process new/changed data |
+| SCD Type 2 tracking | `snapshot` | Track historical changes |
+| One-off analysis | `ephemeral` | No need to persist |
+
+### Warehouse-Specific Configuration
+
+| Feature | Snowflake | BigQuery |
+|---------|-----------|----------|
+| **Incremental default** | `merge` | `merge` |
+| **Recommended for events** | `microbatch` (1.9+) | `insert_overwrite` |
+| **Clustering** | `cluster_by` (automatic) | `cluster_by` (manual) |
+| **Partitioning** | Automatic micro-partitions | `partition_by` (required for large tables) |
+| **Transient tables** | `transient: true` (no fail-safe) | N/A |
+| **Dynamic tables** | `materialized: dynamic_table` | N/A |
+| **Cost model** | Credits (compute time) | Bytes scanned (on-demand) / Slots (flat-rate) |
+
+**For detailed incremental strategies, see:** [Incremental Models & Performance](references/incremental-performance.md)
+
+## Source Configuration
+
+```yaml
+# _stripe__sources.yml
+version: 2
+
+sources:
+  - name: stripe
+    description: "Stripe payment data loaded by Fivetran"
+    database: raw                     # Snowflake: database name
+    schema: stripe                    # Snowflake: schema name
+    loader: fivetran
+    loaded_at_field: _fivetran_synced # For freshness checks
+    freshness:
+      warn_after: {count: 12, period: hour}
+      error_after: {count: 24, period: hour}
+    tables:
+      - name: payments
+        description: "One record per payment attempt"
+        columns:
+          - name: id
+            description: "Primary key"
+            data_tests:
+              - unique
+              - not_null
+          - name: order_id
+            description: "Foreign key to orders"
+            data_tests:
+              - not_null
+              - relationships:
+                  to: source('shopify', 'orders')
+                  field: id
+```
+
+### Warehouse Terminology
+
+| Concept | Snowflake | BigQuery |
+|---------|-----------|----------|
+| Top-level container | Database | Project |
+| Schema grouping | Schema | Dataset |
+| Freshness field | `_fivetran_synced` | `_fivetran_synced` or `_PARTITIONTIME` |
+
+## Basic Testing Overview
+
+### Testing Pyramid
+
+```
+          /\
+         /  \        Singular Tests (specific business rules)
+        /____\
+       /      \      Generic Tests (reusable patterns)
+      /________\
+     /          \    Schema Tests (YAML-configured)
+    /____________\
+   /              \  Source Freshness (automated)
+  /________________\
+```
+
+### What to Test at Each Layer
+
+| Layer | Test Type | Examples |
+|-------|-----------|---------|
+| **Sources** | Freshness, existence | `loaded_at_field`, `not_null` on keys |
+| **Staging** | Primary key integrity | `unique`, `not_null` on PK |
+| **Intermediate** | Tested via downstream models | — |
+| **Marts** | Full coverage | All keys, accepted values, relationships, row counts |
+
+### Quick Test Example
+
+```yaml
+# _finance__models.yml
+version: 2
+
+models:
+  - name: fct_orders
+    description: "One record per order with payment details"
+    columns:
+      - name: order_id
+        description: "Primary key"
+        data_tests:
+          - unique
+          - not_null
+      - name: order_status
+        data_tests:
+          - accepted_values:
+              values: ['completed', 'pending', 'cancelled', 'refunded']
+      - name: total_amount
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+```
+
+**For deep testing strategies, see:** [Testing & Quality Strategy](references/testing-quality.md)
+
+## ref() and source() Patterns
+
+### Rules
+
+1. **`source()` only in staging** — staging models are the only gateway to raw data
+2. **`ref()` everywhere else** — all other models reference through `ref()`
+3. **Never skip layers** — marts must not `ref()` staging directly (go through intermediate)
+4. **Never hardcode schema names** — use `source()` and `ref()` exclusively
+
+### Correct DAG Flow
+
+```
+source('stripe', 'payments')  →  stg_stripe__payments
+                                       ↓
+                                 int_payments_pivoted
+                                       ↓
+                                   fct_orders
+```
+
+### Anti-patterns
+
+```sql
+-- WRONG: Hardcoded table reference
+select * from raw.stripe.payments
+
+-- WRONG: source() outside staging
+-- (in a marts model)
+select * from {{ source('stripe', 'payments') }}
+
+-- WRONG: Skipping layers
+-- (in a marts model referencing staging directly)
+select * from {{ ref('stg_stripe__payments') }}
+
+-- CORRECT: Follow the DAG
+select * from {{ ref('int_payments_pivoted') }}
+```
+
+## Common Commands Cheat Sheet
+
+### Build & Run
+
+| Command | Purpose |
+|---------|---------|
+| `dbt run` | Run all models |
+| `dbt test` | Run all tests |
+| `dbt build` | Run + test in DAG order (recommended) |
+| `dbt compile` | Compile SQL without executing |
+| `dbt run --select fct_orders` | Run a single model |
+| `dbt build --select +fct_orders` | Build model and all ancestors |
+| `dbt build --select fct_orders+` | Build model and all descendants |
+
+### Selectors
+
+| Selector | Meaning |
+|----------|---------|
+| `-s model_name` | Select a single model |
+| `-s +model_name` | Model + all upstream ancestors |
+| `-s model_name+` | Model + all downstream descendants |
+| `-s +model_name+` | Model + all ancestors + descendants |
+| `-s tag:finance` | All models tagged `finance` |
+| `-s path:models/marts` | All models in a directory |
+| `-s state:modified+` | Modified models + descendants (Slim CI) |
+
+### Utilities
+
+| Command | Purpose |
+|---------|---------|
+| `dbt deps` | Install packages from packages.yml |
+| `dbt seed` | Load CSV seeds into warehouse |
+| `dbt snapshot` | Execute snapshot models |
+| `dbt source freshness` | Check source freshness |
+| `dbt docs generate` | Generate documentation site |
+| `dbt docs serve` | Serve documentation locally |
+| `dbt debug` | Test database connection |
+| `dbt clean` | Remove compiled artifacts |
+
+## Warehouse Quick Reference
+
+| Configuration | Snowflake | BigQuery |
+|--------------|-----------|----------|
+| **Profile target** | `type: snowflake` | `type: bigquery` |
+| **Auth method** | User/password or key-pair | OAuth or service account |
+| **Schema generation** | `database.schema.model` | `project.dataset.model` |
+| **Incremental default** | `merge` (using `unique_key`) | `merge` (using `unique_key`) |
+| **Partitioning** | Automatic micro-partitions | `partition_by: {field, data_type}` |
+| **Clustering** | `{{ config(cluster_by=['col']) }}` | `{{ config(cluster_by=['col']) }}` |
+| **Cost optimization** | Warehouse auto-suspend, transient tables | Partition pruning, BI Engine caching |
+| **Connection test** | `dbt debug` | `dbt debug` |
+
+## Detailed Guides
+
+This skill uses **progressive disclosure** — essential information is in this main file, detailed guides are available when needed:
+
+**Reference Files:**
+- **[Testing & Quality Strategy](references/testing-quality.md)** — Deep dive into schema tests, generic tests, singular tests, unit tests, dbt-expectations, and layer-specific testing strategy
+- **[CI/CD & Deployment](references/ci-cd-deployment.md)** — Local dev workflows, Slim CI, GitHub Actions, dbt Cloud jobs, environment strategy, blue/green deployment, SQLFluff
+- **[Jinja, Macros & Packages](references/jinja-macros-packages.md)** — Jinja fundamentals, custom macros, essential packages (dbt-utils, dbt-expectations), debugging, warehouse-adaptive patterns
+- **[Incremental Models & Performance](references/incremental-performance.md)** — Microbatch (1.9+), merge, delete+insert, insert_overwrite, Snowflake/BigQuery performance tuning, cost monitoring
+- **[Data Quality & Observability](references/data-quality-observability.md)** — Source freshness, Elementary package, anomaly detection, alerting, lineage, incident response
+- **[Semantic Layer & Governance](references/semantic-layer-governance.md)** — MetricFlow, model contracts, versions, access controls, dbt Mesh, maturity assessment
+
+**How to use:** When you need detailed information on a topic, reference the appropriate guide. Claude will load it on demand to provide comprehensive guidance.
+
+## License
+
+This skill is licensed under the **Apache License 2.0**. See the LICENSE file for full terms.
+
+**Copyright 2026 Daniel Song**

--- a/skills/dbt-skill/references/ci-cd-deployment.md
+++ b/skills/dbt-skill/references/ci-cd-deployment.md
@@ -1,0 +1,684 @@
+# CI/CD & Deployment
+
+> **Part of:** [dbt-skill](../SKILL.md)
+> **Purpose:** Local dev workflows, Slim CI, GitHub Actions, dbt Cloud jobs, environment strategy, blue/green deployment, cost optimization, and SQLFluff integration
+
+---
+
+## Table of Contents
+
+1. [Development Workflow](#development-workflow)
+2. [Slim CI](#slim-ci)
+3. [GitHub Actions Workflow](#github-actions-workflow)
+4. [dbt Cloud Job Configuration](#dbt-cloud-job-configuration)
+5. [Environment Strategy](#environment-strategy)
+6. [Blue/Green Deployment](#bluegreen-deployment)
+7. [Cost Optimization](#cost-optimization)
+8. [SQLFluff Integration](#sqlfluff-integration)
+
+---
+
+## Development Workflow
+
+### Local Dev Loop
+
+```
+edit SQL -> dbt compile --select model  -> dbt run --select model  -> dbt test --select model  -> iterate
+```
+
+Prefer `dbt build` over separate `dbt run` + `dbt test`. Build executes in DAG order, running tests immediately after each model materializes.
+
+```bash
+# DO: build runs + tests in DAG order
+dbt build --select +fct_orders
+
+# DON'T: run everything, then test everything (late failure detection)
+dbt run --select +fct_orders && dbt test --select +fct_orders
+```
+
+### dbt compile for SQL Inspection
+
+Use `dbt compile` to preview generated SQL without executing. Output lands in `target/compiled/`.
+
+```bash
+dbt compile --select stg_stripe__payments
+cat target/compiled/my_project/models/staging/stripe/stg_stripe__payments.sql
+```
+
+### Defer to Production Artifacts
+
+Use `--defer` and `--state` to reference production artifacts during local development, avoiding full DAG rebuilds.
+
+```bash
+mkdir -p ./prod-artifacts
+cp /path/to/production/manifest.json ./prod-artifacts/
+
+# build only modified models, defer upstream refs to prod
+dbt build --select state:modified+ --defer --state ./prod-artifacts
+```
+
+### profiles.yml for Local Development
+
+Store in `~/.dbt/profiles.yml` (never commit this file).
+
+**Snowflake:**
+
+```yaml
+my_project:
+  target: dev
+  outputs:
+    dev:
+      type: snowflake
+      account: "{{ env_var('SNOWFLAKE_ACCOUNT') }}"
+      user: "{{ env_var('SNOWFLAKE_USER') }}"
+      password: "{{ env_var('SNOWFLAKE_PASSWORD') }}"
+      role: transformer
+      database: analytics
+      warehouse: dev_wh
+      schema: "dev_{{ env_var('USER') }}"    # dev_jsmith
+      threads: 4
+```
+
+**BigQuery:**
+
+```yaml
+my_project:
+  target: dev
+  outputs:
+    dev:
+      type: bigquery
+      method: oauth                          # use gcloud auth for local dev
+      project: my-analytics-project
+      dataset: "dev_{{ env_var('USER') }}"   # dev_jsmith
+      threads: 4
+      location: US
+```
+
+Run `dbt debug` to verify the connection before starting development.
+
+---
+
+## Slim CI
+
+### What It Is
+
+Slim CI builds and tests only modified models plus their downstream descendants, using dbt's state comparison against a previous `manifest.json`.
+
+| Approach | Models Built | Duration | Cost |
+|----------|-------------|----------|------|
+| Full build (500 models) | 500 | 30-45 min | High |
+| Slim CI | 5-20 | 2-5 min | Low |
+
+### state:modified+ Selector
+
+| Selector | Meaning |
+|----------|---------|
+| `state:modified` | Only models with SQL, config, or schema changes |
+| `state:modified+` | Modified models + all downstream descendants |
+| `state:new` | Newly added models |
+| `state:modified+ state:new+` | Modified and new, plus all descendants |
+
+The `+` suffix is critical -- a change to `stg_stripe__payments` must also rebuild `int_payments_pivoted`, `fct_orders`, and any downstream model.
+
+### manifest.json Artifacts
+
+Produced by every `dbt run`, `dbt build`, or `dbt compile` in `target/`. Store production artifacts for CI comparison:
+
+| Method | How |
+|--------|-----|
+| GitHub Actions artifact | Upload after prod deploy, download in CI |
+| S3/GCS bucket | Write on deploy, read in CI |
+| dbt Cloud | Automatic via `--defer` in CI jobs |
+
+### --empty Flag (dbt 1.8+)
+
+Run models with `limit 0` injected into all `ref()` and `source()` calls -- zero warehouse cost, validates SQL compilation and schemas only.
+
+```bash
+dbt build --select state:modified+ --defer --state ./prod-artifacts --empty
+```
+
+Use `--empty` as a fast first gate. Follow with a real Slim CI build for data-level validation.
+
+---
+
+## GitHub Actions Workflow
+
+### Snowflake CI Workflow
+
+```yaml
+# .github/workflows/dbt-ci.yml
+name: dbt Slim CI
+
+on:
+  pull_request:
+    branches: [main]
+
+env:
+  DBT_PROFILES_DIR: .
+
+jobs:
+  dbt-ci:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dbt
+        run: pip install dbt-snowflake
+
+      - name: Create profiles.yml
+        run: |
+          cat <<EOF > profiles.yml
+          my_project:
+            target: ci
+            outputs:
+              ci:
+                type: snowflake
+                account: "${{ secrets.SNOWFLAKE_ACCOUNT }}"
+                user: "${{ secrets.SNOWFLAKE_CI_USER }}"
+                password: "${{ secrets.SNOWFLAKE_CI_PASSWORD }}"
+                role: ci_role
+                database: analytics
+                warehouse: ci_wh_xs
+                schema: "ci_pr_${{ github.event.pull_request.number }}"
+                threads: 4
+          EOF
+
+      - run: dbt deps
+
+      - name: Download production manifest
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          name: dbt-prod-manifest
+          workflow: dbt-prod-deploy.yml
+          branch: main
+          path: ./prod-artifacts
+        continue-on-error: true    # first run won't have artifacts
+
+      - name: dbt build (Slim CI)
+        run: |
+          if [ -f ./prod-artifacts/manifest.json ]; then
+            dbt build --select state:modified+ --defer --state ./prod-artifacts
+          else
+            dbt build
+          fi
+
+      - name: Comment PR with results
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const r = JSON.parse(fs.readFileSync('target/run_results.json', 'utf8'));
+            const passed = r.results.filter(x => x.status === 'pass').length;
+            const failed = r.results.filter(x => x.status === 'fail' || x.status === 'error').length;
+            const icon = failed > 0 ? ':x:' : ':white_check_mark:';
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner, repo: context.repo.repo,
+              body: `## ${icon} dbt CI\n| Passed | Failed | Total |\n|--------|--------|-------|\n| ${passed} | ${failed} | ${r.results.length} |`
+            });
+```
+
+### BigQuery CI -- Key Differences
+
+Replace the install and profiles steps:
+
+```yaml
+      - run: pip install dbt-bigquery
+
+      - uses: google-github-actions/auth@v2
+        with:
+          credentials_json: "${{ secrets.GCP_SA_KEY }}"
+
+      - name: Create profiles.yml
+        run: |
+          cat <<EOF > profiles.yml
+          my_project:
+            target: ci
+            outputs:
+              ci:
+                type: bigquery
+                method: service-account
+                project: my-analytics-project
+                dataset: "ci_pr_${{ github.event.pull_request.number }}"
+                threads: 4
+                location: US
+                keyfile: "${{ steps.auth.outputs.credentials_file_path }}"
+                maximum_bytes_billed: 10000000000    # 10 GB safety limit
+          EOF
+```
+
+### Production Deploy Workflow
+
+Capture the production manifest for future Slim CI runs:
+
+```yaml
+# .github/workflows/dbt-prod-deploy.yml
+name: dbt Production Deploy
+on:
+  push:
+    branches: [main]
+    paths: ["models/**", "macros/**", "tests/**", "dbt_project.yml", "packages.yml"]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - run: pip install dbt-snowflake    # or dbt-bigquery
+      # ... create profiles.yml for prod (same pattern as CI) ...
+      - run: dbt deps && dbt build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dbt-prod-manifest
+          path: target/manifest.json
+          retention-days: 90
+```
+
+---
+
+## dbt Cloud Job Configuration
+
+### CI Job (Triggered on PR)
+
+| Setting | Value |
+|---------|-------|
+| **Trigger** | Pull request to main |
+| **Commands** | `dbt build --select state:modified+ --defer --favor-state` |
+| **Defer to** | Production environment |
+| **Schema** | `ci_pr_{{ env_var('DBT_CLOUD_PR_ID') }}` |
+
+### Production Job (Triggered on Merge)
+
+| Setting | Value |
+|---------|-------|
+| **Trigger** | On merge to main |
+| **Commands** | `dbt build` |
+| **Generate docs** | Enabled |
+| **Run source freshness** | Enabled |
+
+### Scheduled Full Refresh
+
+| Setting | Value |
+|---------|-------|
+| **Trigger** | Cron: `0 4 * * *` (4 AM UTC daily) |
+| **Commands** | `dbt build --full-refresh --select config.materialized:incremental` |
+
+Rebuild incremental models nightly to clear drift from late-arriving data.
+
+### Environment Variables
+
+| Variable | Scope | Example |
+|----------|-------|---------|
+| `DBT_CLOUD_PR_ID` | CI | Auto-populated |
+| `DBT_TARGET_SCHEMA` | Per env | `prod`, `staging` |
+| `DBT_WAREHOUSE` | Per env | `prod_wh`, `ci_wh_xs` |
+| `DBT_THREADS` | Per env | `8` (prod), `4` (ci) |
+
+### Job Chaining
+
+Configure in dbt Cloud under **Triggers** > "Run when another job completes":
+
+```
+Source Freshness Check -> Production Build -> Documentation Generation
+```
+
+---
+
+## Environment Strategy
+
+### Schema-Based Environments
+
+| Environment | Schema Pattern | Example |
+|-------------|---------------|---------|
+| Local dev | `dev_<username>` | `dev_jsmith` |
+| CI | `ci_pr_<number>` | `ci_pr_142` |
+| Staging | `staging` | `staging` |
+| Production | `prod` | `prod` |
+
+### generate_schema_name Override
+
+```sql
+-- macros/generate_schema_name.sql
+{% macro generate_schema_name(custom_schema_name, node) -%}
+    {%- set default_schema = target.schema -%}
+    {%- if target.name == 'prod' -%}
+        {#-- prod: use custom schema directly (e.g., "finance") --#}
+        {{ custom_schema_name | trim if custom_schema_name is not none else default_schema }}
+    {%- else -%}
+        {#-- dev/ci: prefix with target schema (e.g., "dev_jsmith_finance") --#}
+        {%- if custom_schema_name is not none -%}
+            {{ default_schema }}_{{ custom_schema_name | trim }}
+        {%- else -%}
+            {{ default_schema }}
+        {%- endif -%}
+    {%- endif -%}
+{%- endmacro %}
+```
+
+| Target | Custom Schema | Result |
+|--------|--------------|--------|
+| prod | `finance` | `finance` |
+| prod | (none) | `prod` |
+| dev | `finance` | `dev_jsmith_finance` |
+| ci | `finance` | `ci_pr_142_finance` |
+
+### generate_database_name (Snowflake Multi-Database)
+
+```sql
+-- macros/generate_database_name.sql
+{% macro generate_database_name(custom_database_name, node) -%}
+    {%- set default_database = target.database -%}
+    {%- if target.name == 'prod' and custom_database_name is not none -%}
+        {{ custom_database_name | trim }}
+    {%- else -%}
+        {{ default_database }}
+    {%- endif -%}
+{%- endmacro %}
+```
+
+Prevents dev runs from writing to production databases.
+
+### Target-Based Conditional Config
+
+```yaml
+# dbt_project.yml -- global config
+models:
+  my_project:
+    staging:
+      +materialized: view
+    intermediate:
+      +materialized: ephemeral
+    marts:
+      +materialized: "{{ 'table' if target.name == 'prod' else 'view' }}"
+```
+
+```sql
+-- per-model config
+{{ config(
+    materialized = 'view' if target.name == 'dev' else 'table',
+    cluster_by = ['order_date'] if target.name == 'prod' else none
+) }}
+```
+
+```yaml
+# DO: views in dev for speed, tables in prod for BI
+marts:
+  +materialized: "{{ 'table' if target.name == 'prod' else 'view' }}"
+
+# DON'T: incremental in dev (unnecessary complexity)
+staging:
+  +materialized: "{{ 'incremental' if target.name == 'prod' else 'view' }}"
+```
+
+---
+
+## Blue/Green Deployment
+
+### Concept
+
+Build into a shadow schema (green), verify, then atomically swap with the live schema (blue).
+
+```
+Production (blue):  analytics.prod         <- BI tools point here
+Shadow (green):     analytics.prod_shadow  <- dbt builds here
+                         |
+    After validation:  SWAP blue <-> green
+```
+
+### Snowflake: Atomic Schema Swap
+
+```sql
+-- macros/blue_green_swap.sql
+{% macro blue_green_swap(database, live_schema, shadow_schema) %}
+    {% set swap_query %}
+        alter schema {{ database }}.{{ live_schema }}
+            swap with {{ database }}.{{ shadow_schema }};
+    {% endset %}
+    {% do run_query(swap_query) %}
+    {{ log("Swapped " ~ live_schema ~ " with " ~ shadow_schema, info=True) }}
+{% endmacro %}
+```
+
+```bash
+dbt run-operation blue_green_swap \
+    --args '{database: analytics, live_schema: prod, shadow_schema: prod_shadow}'
+```
+
+### BigQuery: View Routing
+
+BigQuery lacks schema swaps. Route views to the new dataset instead:
+
+```sql
+-- macros/bigquery_blue_green.sql
+{% macro update_routing_views(prod_dataset, shadow_dataset) %}
+    {% set models = graph.nodes.values()
+        | selectattr("resource_type", "equalto", "model")
+        | selectattr("config.materialized", "in", ["table", "incremental"])
+        | list %}
+    {% for model in models %}
+        {% set q %}
+            create or replace view `{{ target.project }}.{{ prod_dataset }}.{{ model.name }}` as
+            select * from `{{ target.project }}.{{ shadow_dataset }}.{{ model.name }}`;
+        {% endset %}
+        {% do run_query(q) %}
+    {% endfor %}
+{% endmacro %}
+```
+
+### When to Use Blue/Green
+
+| Scenario | Approach | Reason |
+|----------|----------|--------|
+| Small project (< 50 models) | Direct deploy | Low risk, fast rebuild |
+| Large project with BI consumers | Blue/green | Zero-downtime swap |
+| Incremental-heavy project | Direct deploy | Full rebuild too expensive |
+| SLA-critical / regulated | Blue/green | Atomic cutover, instant rollback |
+
+### Rollback
+
+**Snowflake:** Swap schemas back. Keep the old schema for 24h before dropping.
+
+```sql
+alter schema analytics.prod swap with analytics.prod_shadow;    -- instant rollback
+```
+
+**BigQuery:** Re-point routing views to the previous dataset.
+
+**Snowflake Time Travel:** Query previous state without swapping:
+
+```sql
+select * from analytics.prod.fct_orders at (offset => -3600);
+```
+
+---
+
+## Cost Optimization
+
+### Snowflake Warehouse Sizing
+
+| Environment | Size | Auto-Suspend |
+|-------------|------|-------------|
+| CI | X-SMALL | 60s |
+| Dev | X-SMALL | 120s |
+| Staging | SMALL | 300s |
+| Production | MEDIUM+ | 300s |
+
+```sql
+create warehouse if not exists ci_wh_xs
+    warehouse_size = 'X-SMALL'
+    auto_suspend = 60
+    auto_resume = true
+    initially_suspended = true;
+```
+
+### BigQuery Cost Controls
+
+Set `maximum_bytes_billed` in profiles to cap per-query cost. For flat-rate pricing, assign CI to a separate reservation with limited slots.
+
+### Schema Cleanup After Merge
+
+```sql
+-- macros/drop_pr_schema.sql
+{% macro drop_pr_schema(pr_number) %}
+    {% set drop_query %}
+        drop schema if exists {{ target.database }}.ci_pr_{{ pr_number }} cascade;
+    {% endset %}
+    {% do run_query(drop_query) %}
+    {{ log("Dropped schema: ci_pr_" ~ pr_number, info=True) }}
+{% endmacro %}
+```
+
+Automate via GitHub Actions on PR close:
+
+```yaml
+# .github/workflows/dbt-cleanup.yml
+name: Cleanup PR Schema
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: pip install dbt-snowflake
+      - run: dbt run-operation drop_pr_schema --args '{pr_number: ${{ github.event.pull_request.number }}}'
+```
+
+### Monitoring CI Costs
+
+**Snowflake:**
+
+```sql
+select date_trunc('week', start_time) as week, sum(credits_used) as ci_credits
+from snowflake.account_usage.warehouse_metering_history
+where warehouse_name = 'CI_WH_XS'
+    and start_time >= dateadd('month', -3, current_timestamp())
+group by 1 order by 1;
+```
+
+**BigQuery:**
+
+```sql
+select date_trunc(creation_time, week) as week,
+    sum(total_bytes_billed) / power(1024, 4) as tb_billed
+from `region-us`.INFORMATION_SCHEMA.JOBS
+where destination_table.dataset_id like 'ci_pr_%'
+    and creation_time >= timestamp_sub(current_timestamp(), interval 90 day)
+group by 1 order by 1;
+```
+
+---
+
+## SQLFluff Integration
+
+### What SQLFluff Is
+
+SQLFluff is a SQL linter and auto-formatter that understands dbt's Jinja templating. It catches style inconsistencies and auto-fixes common issues before code review.
+
+### .sqlfluff Configuration
+
+```ini
+[sqlfluff]
+templater = dbt
+dialect = snowflake
+# for BigQuery: dialect = bigquery
+max_line_length = 120
+indent_unit = space
+
+[sqlfluff:indentation]
+tab_space_size = 4
+
+[sqlfluff:layout:type:comma]
+line_position = leading              # leading commas
+
+[sqlfluff:rules:capitalisation.keywords]
+capitalisation_policy = lower        # select, not SELECT
+
+[sqlfluff:rules:capitalisation.identifiers]
+extended_capitalisation_policy = lower
+
+[sqlfluff:rules:capitalisation.functions]
+extended_capitalisation_policy = lower
+
+[sqlfluff:rules:aliasing.table]
+aliasing = explicit                  # "from t as t" not "from t t"
+
+[sqlfluff:rules:aliasing.column]
+aliasing = explicit
+```
+
+### Rules Reference
+
+| Rule | Recommendation | Reason |
+|------|---------------|--------|
+| `capitalisation.keywords` | Enable (lower) | Match dbt conventions |
+| `aliasing.table` | Enable (explicit) | Readability |
+| `layout.type:comma` | Enable (leading) | Cleaner diffs |
+| `ambiguous.column_references` | Enable | Prevent ambiguous joins |
+| `structure.subquery` | Disable | dbt CTEs handle this |
+| `jinja.padding` | Enable | Consistent Jinja spacing |
+
+### Pre-commit Hook
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/sqlfluff/sqlfluff
+    rev: 3.3.0
+    hooks:
+      - id: sqlfluff-lint
+        additional_dependencies: [dbt-snowflake]
+        args: [--dialect, snowflake]
+      - id: sqlfluff-fix
+        additional_dependencies: [dbt-snowflake]
+        args: [--dialect, snowflake, --force]
+```
+
+### CI Integration
+
+```yaml
+# add to dbt-ci.yml
+      - run: pip install sqlfluff dbt-snowflake
+      - name: Lint SQL
+        run: sqlfluff lint models/ --dialect snowflake --format github-annotation
+```
+
+The `github-annotation` format produces inline annotations on the PR diff.
+
+**DO/DON'T:**
+
+```sql
+-- DO: lowercase keywords, leading commas, explicit aliases
+select
+    orders.order_id
+    , orders.customer_id
+    , payments.total_amount
+from {{ ref('stg_shopify__orders') }} as orders
+left join {{ ref('int_payments_pivoted') }} as payments
+    on orders.order_id = payments.order_id
+
+-- DON'T: uppercase keywords, trailing commas, implicit aliases
+SELECT
+    o.order_id,
+    o.customer_id,
+    p.total_amount
+FROM {{ ref('stg_shopify__orders') }} o
+LEFT JOIN {{ ref('int_payments_pivoted') }} p
+    ON o.order_id = p.order_id
+```
+
+---
+
+**Back to:** [Main Skill File](../SKILL.md)

--- a/skills/dbt-skill/references/data-quality-observability.md
+++ b/skills/dbt-skill/references/data-quality-observability.md
@@ -1,0 +1,744 @@
+# Data Quality & Observability
+
+> **Part of:** [dbt-skill](../SKILL.md)
+> **Purpose:** Source freshness monitoring, anomaly detection, alerting, lineage analysis, and incident response for dbt projects
+
+For basic testing and source configuration, see the [main skill file](../SKILL.md#basic-testing-overview).
+
+---
+
+## Table of Contents
+
+1. [Source Freshness](#source-freshness)
+2. [Elementary Package](#elementary-package)
+3. [Anomaly Detection Patterns](#anomaly-detection-patterns)
+4. [Data Quality Metrics](#data-quality-metrics)
+5. [Alerting](#alerting)
+6. [Lineage & Impact Analysis](#lineage--impact-analysis)
+7. [Incident Response](#incident-response)
+8. [Three-Tier Adoption Path](#three-tier-adoption-path)
+
+---
+
+## Source Freshness
+
+Configure `loaded_at_field` and threshold values in sources YAML, then run `dbt source freshness` to check.
+
+### loaded_at_field by Platform
+
+| Ingestion Tool | loaded_at_field | Notes |
+|----------------|----------------|-------|
+| Fivetran | `_fivetran_synced` | Added automatically to every table |
+| Airbyte | `_airbyte_extracted_at` | Available in raw tables |
+| Stitch | `_sdc_batched_at` | Stitch metadata column |
+| BigQuery native | `_PARTITIONTIME` | Pseudo-column on ingestion-time partitioned tables |
+| Custom pipeline | `loaded_at` / `updated_at` | Define in your ETL process |
+
+### Complete Source Freshness Example
+
+```yaml
+# _shopify__sources.yml
+version: 2
+
+sources:
+  - name: shopify
+    description: "Shopify e-commerce data loaded by Fivetran"
+    database: raw
+    schema: shopify
+    loader: fivetran
+    loaded_at_field: _fivetran_synced      # timestamp column to check
+    freshness:
+      warn_after: {count: 12, period: hour}  # yellow alert
+      error_after: {count: 24, period: hour} # red alert
+    tables:
+      - name: orders
+        columns:
+          - name: id
+            data_tests: [unique, not_null]
+      - name: customers
+        freshness:                           # override source-level thresholds
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
+      - name: order_events
+        loaded_at_field: event_timestamp     # override source-level field
+        freshness:
+          warn_after: {count: 1, period: hour}
+          error_after: {count: 3, period: hour}
+```
+
+**BigQuery with `_PARTITIONTIME`:**
+
+```yaml
+sources:
+  - name: ga4
+    database: "{{ var('gcp_project') }}"
+    schema: analytics_123456789
+    loaded_at_field: _PARTITIONTIME          # BigQuery pseudo-column
+    freshness:
+      warn_after: {count: 26, period: hour}
+      error_after: {count: 50, period: hour}
+```
+
+### Running Freshness Checks
+
+```bash
+dbt source freshness                           # check all sources
+dbt source freshness --select source:shopify   # check single source
+dbt source freshness --output json > target/sources.json  # JSON for automation
+```
+
+**Example output:**
+
+```
+Running freshness check on source shopify.orders ...
+  max_loaded_at = 2026-02-12 08:15:22+00:00
+  snapshotted_at = 2026-02-12 09:00:00+00:00
+  age = 0:44:38     status = PASS
+
+Running freshness check on source shopify.customers ...
+  max_loaded_at = 2026-02-11 02:30:00+00:00
+  age = 30:30:00     status = WARN
+```
+
+### Scheduling Freshness in CI/CD
+
+```yaml
+# .github/workflows/source-freshness.yml
+name: Source Freshness Check
+on:
+  schedule:
+    - cron: '0 */2 * * *'                     # every 2 hours
+jobs:
+  freshness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.11' }
+      - run: pip install dbt-snowflake         # or dbt-bigquery
+      - run: dbt deps && dbt source freshness
+        env: { DBT_PROFILES_DIR: ./ci_profiles }
+```
+
+---
+
+## Elementary Package
+
+[Elementary](https://www.elementary-data.com/) adds anomaly detection, schema monitoring, and observability reporting directly inside your warehouse.
+
+### Installation and Configuration
+
+```yaml
+# packages.yml
+packages:
+  - package: elementary-data/elementary
+    version: "0.16.1"                          # pin to specific version
+```
+
+```yaml
+# dbt_project.yml
+models:
+  elementary:
+    +schema: elementary                        # isolate in own schema
+    +materialized: table
+```
+
+```bash
+dbt deps && dbt run --select elementary        # install and create models
+```
+
+### Anomaly Tests
+
+```yaml
+# _finance__models.yml
+models:
+  - name: fct_orders
+    config:
+      tags: ['finance', 'daily']
+    columns:
+      - name: order_id
+        data_tests:
+          - unique
+          - not_null
+          - elementary.volume_anomalies:       # row count anomaly detection
+              timestamp_column: order_date
+              where: "order_date >= current_date - 90"
+              time_bucket: {period: day, count: 1}
+              sensitivity: 3                   # standard deviations
+      - name: order_date
+        data_tests:
+          - elementary.freshness_anomalies:    # data arrival delay detection
+              timestamp_column: order_date
+              sensitivity: 3
+      - name: order_id
+        data_tests:
+          - elementary.schema_changes:         # column add/remove/type change
+              tags: ['schema_monitor']
+```
+
+### Report and Slack Integration
+
+```bash
+dbt run-operation elementary.generate_report   # HTML report at target/elementary_report.html
+dbt run-operation elementary.send_slack_report  # send alerts to Slack
+```
+
+```yaml
+# dbt_project.yml — Slack webhook config
+vars:
+  elementary:
+    slack_webhook: "{{ env_var('ELEMENTARY_SLACK_WEBHOOK') }}"
+    slack_channel_name: "#data-alerts"
+    slack_group_alerts_by: "table"
+```
+
+**Setup sequence:** install package, run elementary models, add anomaly tests to YAML, run `dbt test`, generate report, configure Slack, send first alert.
+
+---
+
+## Anomaly Detection Patterns
+
+Use these DIY patterns when Elementary is unavailable, or as supplementary checks.
+
+### Row Count Monitoring Macro
+
+```sql
+-- macros/test_row_count_anomaly.sql
+{% macro test_row_count_anomaly(model, timestamp_column, lookback_days=30, sensitivity=3) %}
+with daily_counts as (
+    select
+        date_trunc('day', {{ timestamp_column }}) as check_date,
+        count(*) as row_count
+    from {{ model }}
+    where {{ timestamp_column }} >= current_date - {{ lookback_days }}
+    group by 1
+),
+stats as (
+    select avg(row_count) as avg_count, stddev(row_count) as stddev_count
+    from daily_counts
+    where check_date < current_date            -- exclude today (partial)
+),
+today as (
+    select check_date, row_count
+    from daily_counts where check_date = current_date
+)
+select t.check_date, t.row_count, s.avg_count,
+    s.avg_count - ({{ sensitivity }} * s.stddev_count) as lower_bound,
+    s.avg_count + ({{ sensitivity }} * s.stddev_count) as upper_bound
+from today t cross join stats s
+where t.row_count < s.avg_count - ({{ sensitivity }} * s.stddev_count)
+   or t.row_count > s.avg_count + ({{ sensitivity }} * s.stddev_count)
+{% endmacro %}
+```
+
+### Order Count Anomaly (Singular Test)
+
+```sql
+-- tests/assert_order_count_within_range.sql
+with daily_counts as (
+    select order_date, count(*) as order_count
+    from {{ ref('fct_orders') }}
+    where order_date >= current_date - 30
+    group by order_date
+),
+stats as (
+    select avg(order_count) as avg_count, stddev(order_count) as stddev_count
+    from daily_counts
+)
+select dc.order_date, dc.order_count
+from daily_counts dc cross join stats s
+where dc.order_count < s.avg_count - (3 * s.stddev_count)
+   or dc.order_count > s.avg_count + (3 * s.stddev_count)
+```
+
+### Column Distribution Drift
+
+```sql
+-- tests/assert_payment_method_distribution.sql
+with current_dist as (
+    select payment_method,
+        count(*) * 1.0 / sum(count(*)) over() as current_pct
+    from {{ ref('fct_orders') }}
+    where order_date >= current_date - 7
+    group by payment_method
+),
+baseline_dist as (
+    select payment_method,
+        count(*) * 1.0 / sum(count(*)) over() as baseline_pct
+    from {{ ref('fct_orders') }}
+    where order_date between current_date - 60 and current_date - 8
+    group by payment_method
+)
+-- fail if any method share shifted >15 percentage points
+select c.payment_method,
+    round(c.current_pct * 100, 1) as current_pct,
+    round(b.baseline_pct * 100, 1) as baseline_pct
+from current_dist c
+left join baseline_dist b on c.payment_method = b.payment_method
+where abs(c.current_pct - coalesce(b.baseline_pct, 0)) > 0.15
+```
+
+### Null Rate Tracking
+
+```sql
+-- tests/assert_null_rate_within_threshold.sql
+with null_rates as (
+    select
+        count(*) as total_rows,
+        sum(case when customer_email is null then 1 else 0 end) as null_email,
+        sum(case when shipping_address is null then 1 else 0 end) as null_address
+    from {{ ref('fct_orders') }}
+    where order_date >= current_date - 7
+)
+select *
+from null_rates
+where null_email * 1.0 / total_rows > 0.05    -- fail if >5% emails null
+   or null_address * 1.0 / total_rows > 0.10  -- fail if >10% addresses null
+```
+
+---
+
+## Data Quality Metrics
+
+### The Four Pillars
+
+| Pillar | Definition | Measurement | Example |
+|--------|-----------|-------------|---------|
+| **Completeness** | Non-null values in required fields | `1 - (null_count / total_count)` | `customer_email` 98% populated |
+| **Accuracy** | Values match expected formats/ranges | Format validation, range checks | `order_total > 0` |
+| **Timeliness** | Data arrives within SLA windows | `now() - max(loaded_at)` | Orders data < 2 hours old |
+| **Consistency** | Cross-source agreement | Sum reconciliation, row counts | Stripe revenue = Shopify revenue |
+
+### Quality Scores Model
+
+```sql
+-- models/marts/observability/fct_data_quality_scores.sql
+{{ config(materialized='incremental', unique_key='quality_check_id') }}
+
+with completeness_checks as (
+    select
+        current_date as check_date,
+        'fct_orders' as model_name,
+        'completeness' as pillar,
+        'customer_email' as column_name,
+        count(*) as total_rows,
+        count(customer_email) as passing_rows,
+        round(count(customer_email) * 100.0 / nullif(count(*), 0), 2) as score
+    from {{ ref('fct_orders') }}
+    where order_date >= current_date - 1
+),
+accuracy_checks as (
+    select
+        current_date as check_date,
+        'fct_orders' as model_name,
+        'accuracy' as pillar,
+        'total_amount' as column_name,
+        count(*) as total_rows,
+        sum(case when total_amount > 0 then 1 else 0 end) as passing_rows,
+        round(sum(case when total_amount > 0 then 1 else 0 end) * 100.0
+            / nullif(count(*), 0), 2) as score
+    from {{ ref('fct_orders') }}
+    where order_date >= current_date - 1
+),
+timeliness_checks as (
+    select
+        current_date as check_date,
+        'fct_orders' as model_name,
+        'timeliness' as pillar,
+        'order_date' as column_name,
+        count(*) as total_rows,
+        count(*) as passing_rows,
+        case when max(order_date) >= current_date - 1 then 100.0 else 0.0 end as score
+    from {{ ref('fct_orders') }}
+),
+all_checks as (
+    select * from completeness_checks union all
+    select * from accuracy_checks union all
+    select * from timeliness_checks
+)
+select
+    {{ dbt_utils.generate_surrogate_key(['check_date','model_name','pillar','column_name']) }}
+        as quality_check_id,
+    check_date, model_name, pillar, column_name, total_rows, passing_rows, score
+from all_checks
+{% if is_incremental() %}
+where check_date > (select max(check_date) from {{ this }})
+{% endif %}
+```
+
+### Exposure for Quality Dashboard
+
+```yaml
+exposures:
+  - name: data_quality_dashboard
+    type: dashboard
+    maturity: high
+    owner: {name: Data Engineering, email: data-eng@company.com}
+    depends_on:
+      - ref('fct_data_quality_scores')
+    url: https://looker.company.com/dashboards/data-quality
+    description: "Tracks quality scores across all mart models for daily monitoring and SLA reporting."
+```
+
+---
+
+## Alerting
+
+### Severity Matrix
+
+| Severity | Condition | Channel | Response Time |
+|----------|-----------|---------|---------------|
+| **P1** | Mart data missing or incorrect | PagerDuty | 15 min |
+| **P2** | Source freshness error threshold | Slack `#data-alerts` | 1 hour |
+| **P3** | Test warning threshold | Slack `#data-notifications` | Next business day |
+| **P4** | Schema change detected | Log only | Weekly review |
+
+### dbt Cloud Webhooks
+
+Configure in dbt Cloud: **Account Settings > Webhooks > Create Webhook**. Payload includes job name, run ID, status, failed models/tests, and run URL.
+
+### Slack Alert Script
+
+```python
+# scripts/dbt_slack_alert.py
+import requests, os
+
+SLACK_WEBHOOK = os.environ["SLACK_WEBHOOK_URL"]
+CHANNELS = {"p1": "#data-incidents", "p2": "#data-alerts", "p3": "#data-notifications"}
+COLORS = {"p1": "#FF0000", "p2": "#FFA500", "p3": "#FFFF00"}
+
+def send_alert(severity, model_name, error_message, run_url):
+    requests.post(SLACK_WEBHOOK, json={
+        "channel": CHANNELS.get(severity, "#data-notifications"),
+        "attachments": [{
+            "color": COLORS.get(severity, "#808080"),
+            "title": f"[{severity.upper()}] dbt failure: {model_name}",
+            "text": error_message,
+            "fields": [
+                {"title": "Model", "value": model_name, "short": True},
+                {"title": "Severity", "value": severity.upper(), "short": True},
+            ],
+            "actions": [{"type": "button", "text": "View Run", "url": run_url}]
+        }]
+    })
+```
+
+### PagerDuty for P1 Incidents
+
+```yaml
+# .github/workflows/dbt-production.yml (partial)
+- name: Alert on P1 failure
+  if: failure()
+  run: |
+    curl -X POST https://events.pagerduty.com/v2/enqueue \
+      -H 'Content-Type: application/json' \
+      -d '{
+        "routing_key": "${{ secrets.PAGERDUTY_ROUTING_KEY }}",
+        "event_action": "trigger",
+        "payload": {
+          "summary": "dbt production build failed - mart data may be stale",
+          "severity": "critical",
+          "source": "dbt-ci",
+          "component": "data-pipeline"
+        }
+      }'
+```
+
+### Alert Fatigue Tuning
+
+| Technique | Implementation | Effect |
+|-----------|---------------|--------|
+| **Severity thresholds** | `warn_after` before `error_after` | Fewer false-positive pages |
+| **Deduplication** | Group alerts by model per run | No alert storms |
+| **Snooze rules** | Suppress known issues 24-48 hours | Time for planned fixes |
+| **Batch notifications** | Daily digest for P3/P4 | Reduced notification volume |
+| **Ownership routing** | Tag with `meta.owner`, route per team | No cross-team noise |
+
+```yaml
+models:
+  - name: fct_orders
+    meta:
+      owner: "finance-analytics"               # route alerts to owning team
+      severity: "p1"
+    config:
+      tags: ['finance', 'p1']
+```
+
+---
+
+## Lineage & Impact Analysis
+
+### Generate and View the DAG
+
+```bash
+dbt docs generate                              # build lineage graph
+dbt docs serve --port 8080                     # serve interactive DAG
+```
+
+### Ancestor and Descendant Queries
+
+```bash
+dbt ls --select +fct_orders                    # all upstream ancestors
+dbt ls --select fct_orders+                    # all downstream descendants
+dbt ls --select +fct_orders+                   # both directions
+```
+
+### Exposure Definitions
+
+```yaml
+# models/marts/finance/_finance__exposures.yml
+version: 2
+
+exposures:
+  - name: weekly_revenue_dashboard
+    type: dashboard
+    maturity: high
+    owner: {name: Analytics Team, email: analytics@company.com}
+    depends_on:
+      - ref('fct_orders')
+      - ref('dim_customers')
+    url: https://looker.company.com/dashboards/123
+    description: "Weekly revenue reporting for the executive team. Refreshes Mondays 6am UTC."
+
+  - name: customer_segmentation_model
+    type: ml
+    maturity: medium
+    owner: {name: Data Science, email: data-science@company.com}
+    depends_on:
+      - ref('fct_orders')
+      - ref('dim_customers')
+      - ref('fct_web_sessions')
+    description: "Customer segmentation for targeted marketing. Retrained weekly on 90 days of data."
+```
+
+### Impact Analysis Workflow
+
+Before changing any model, check downstream dependencies:
+
+```bash
+# 1. List downstream models
+dbt ls --select stg_shopify__orders+
+
+# 2. List affected dashboards and ML models
+dbt ls --select stg_shopify__orders+ --resource-type exposure
+
+# 3. Dry-run build of all affected nodes
+dbt build --select stg_shopify__orders+ --defer --state prod-artifacts/
+```
+
+**DO:** Check `dbt ls --select model+ --resource-type exposure` before modifying any model, then notify owners listed in exposure YAML.
+
+**DON'T:** Push column renames or logic changes without checking downstream impact first.
+
+---
+
+## Incident Response
+
+### Runbook: Six Steps
+
+**1. Detect** -- Alert fires from: dbt test failure, source freshness error, Elementary anomaly, or stakeholder report.
+
+**2. Triage** -- Assess severity using the [matrix above](#severity-matrix).
+
+```bash
+dbt ls --select result:error --state target/   # what failed in last run
+dbt source freshness --select source:shopify   # freshness status
+```
+
+**3. Communicate** -- Notify stakeholders immediately for P1/P2:
+
+```
+Subject: [P{n}] Data Incident - {model_name}
+Status: Investigating
+Impact: {affected data and dashboards}
+Affected dashboards: {from dbt ls --select model+ --resource-type exposure}
+ETA: {estimated resolution time}
+Workaround: {e.g., "use yesterday's snapshot"}
+Updates: every {30 min for P1 | 2 hours for P2}
+```
+
+**4. Fix** -- Common remediation:
+
+```bash
+dbt build --select +fct_orders                 # re-run model + ancestors
+dbt run --select fct_orders --full-refresh     # full refresh if corrupted
+dbt retry                                      # re-run only failed models
+dbt build --select result:error+ --state target/  # failed + downstream
+```
+
+**5. Verify** -- Confirm the fix:
+
+```bash
+dbt build --select +fct_orders+ --resource-type test
+dbt source freshness
+dbt run-operation elementary.generate_report
+```
+
+**6. Post-mortem** -- Document the incident:
+
+```markdown
+# Post-Mortem: {title}
+**Date:** YYYY-MM-DD | **Severity:** P{n} | **Duration:** {time}
+
+## Timeline
+- HH:MM Alert fired | HH:MM Acknowledged | HH:MM Root cause found | HH:MM Fixed | HH:MM Verified
+
+## Root Cause
+{Technical explanation}
+
+## Impact
+Models: {list} | Dashboards: {list} | Data gap: {time range}
+
+## Prevention
+| Action | Owner | Due Date |
+|--------|-------|----------|
+| {measure} | {name} | YYYY-MM-DD |
+```
+
+### Recovery Commands Reference
+
+| Scenario | Command |
+|----------|---------|
+| Re-run failed only | `dbt retry` |
+| Failed + downstream | `dbt build --select result:error+ --state target/` |
+| Full refresh corrupted | `dbt run --select model_name --full-refresh` |
+| Rebuild DAG branch | `dbt build --select +model_name+` |
+| Validate after fix | `dbt test --select +model_name` |
+| Check freshness | `dbt source freshness` |
+
+---
+
+## Three-Tier Adoption Path
+
+| Tier | Label | What to Implement | When |
+|------|-------|-------------------|------|
+| 1 | **Essential** | Source freshness, model contracts, basic YAML tests | Day 1 |
+| 2 | **Mature** | Elementary, Slack alerts, anomaly detection, custom tests | Running in prod |
+| 3 | **Enterprise** | Full observability platform, PagerDuty, SLAs, data quality scores | Multiple teams |
+
+### Tier 1: Essential (Day 1)
+
+Implement on every dbt project from the start.
+
+```yaml
+# Source freshness on all sources
+sources:
+  - name: shopify
+    loaded_at_field: _fivetran_synced
+    freshness:
+      warn_after: {count: 12, period: hour}
+      error_after: {count: 24, period: hour}
+    tables: [orders, customers]
+
+---
+# Primary key tests on every model
+models:
+  - name: fct_orders
+    columns:
+      - name: order_id
+        data_tests: [unique, not_null]
+
+---
+# Model contracts on marts (dbt 1.5+)
+models:
+  - name: fct_orders
+    config:
+      contract: {enforced: true}
+    columns:
+      - name: order_id
+        data_type: string
+        data_tests: [unique, not_null]
+      - name: total_amount
+        data_type: float
+        data_tests: [not_null]
+```
+
+Run freshness in CI: `dbt source freshness && dbt build`
+
+### Tier 2: Mature (Running in Production)
+
+Add once the project actively serves stakeholders.
+
+- Install Elementary (`elementary-data/elementary`, pin version)
+- Add `volume_anomalies` and `freshness_anomalies` tests on critical models
+- Configure Slack webhook for Elementary alerts
+- Write custom anomaly tests for business-critical metrics (revenue, order counts)
+- Define exposures for all dashboards and ML models
+
+```sql
+-- tests/assert_daily_revenue_within_range.sql
+with daily_revenue as (
+    select order_date, sum(total_amount) as revenue
+    from {{ ref('fct_orders') }}
+    where order_date >= current_date - 30
+    group by order_date
+),
+stats as (
+    select avg(revenue) as avg_rev, stddev(revenue) as std_rev
+    from daily_revenue where order_date < current_date
+)
+select dr.order_date, dr.revenue
+from daily_revenue dr cross join stats s
+where dr.revenue < s.avg_rev - (3 * s.std_rev)
+   or dr.revenue > s.avg_rev + (3 * s.std_rev)
+```
+
+### Tier 3: Enterprise (Multiple Teams)
+
+Implement when scaling to multiple data teams with strict SLAs.
+
+- Schedule Elementary report after every production run
+- Configure PagerDuty for P1 incidents (see [PagerDuty section](#pagerduty-for-p1-incidents))
+- Define SLA metadata per model tier:
+
+```yaml
+# dbt_project.yml
+models:
+  my_project:
+    marts:
+      finance:
+        +meta: {sla: "data by 06:00 UTC", owner: finance-analytics, tier: p1}
+      marketing:
+        +meta: {sla: "data by 09:00 UTC", owner: marketing-analytics, tier: p2}
+```
+
+- Build quality scoring dashboard on `fct_data_quality_scores`
+- Automate incident triage script:
+
+```bash
+#!/usr/bin/env bash
+# scripts/incident-triage.sh
+set -euo pipefail
+echo "=== Failed models ==="
+dbt ls --select result:error --state target/ 2>/dev/null || echo "No failures"
+echo "=== Source freshness ==="
+dbt source freshness 2>/dev/null || echo "Freshness check failed"
+echo "=== Downstream impact ==="
+for model in $(dbt ls --select result:error --state target/ 2>/dev/null); do
+    echo "--- $model ---"
+    dbt ls --select "${model}+" --resource-type exposure 2>/dev/null || echo "  None"
+done
+```
+
+### Adoption Checklist
+
+| Tier | Item |
+|------|------|
+| 1 | Source freshness configured for all sources |
+| 1 | Primary key tests on every model |
+| 1 | Model contracts on mart models |
+| 1 | Freshness check in CI pipeline |
+| 2 | Elementary installed and configured |
+| 2 | Volume + freshness anomaly tests on critical models |
+| 2 | Slack alerts configured |
+| 2 | Exposures defined for all dashboards |
+| 2 | Custom anomaly tests for key business metrics |
+| 3 | PagerDuty integration for P1 |
+| 3 | SLA definitions per model tier |
+| 3 | Data quality scoring model + dashboard |
+| 3 | Automated incident triage script |
+| 3 | Post-mortem process documented |
+
+---
+
+**Back to:** [Main Skill File](../SKILL.md)

--- a/skills/dbt-skill/references/incremental-performance.md
+++ b/skills/dbt-skill/references/incremental-performance.md
@@ -1,0 +1,1212 @@
+# Incremental Models & Performance
+
+> **Part of:** [dbt-skill](../SKILL.md)
+> **Purpose:** Complete guide to incremental strategies, warehouse-specific performance tuning, and cost optimization for Snowflake and BigQuery
+
+This document covers every incremental materialization strategy, when to use each, warehouse-specific performance techniques, and cost monitoring patterns. For high-level materialization guidance, see the [main skill file](../SKILL.md).
+
+---
+
+## Table of Contents
+
+1. [Incremental Strategy Decision Matrix](#1-incremental-strategy-decision-matrix)
+2. [Microbatch Deep Dive (dbt 1.9+)](#2-microbatch-deep-dive-dbt-19)
+3. [Traditional Incremental Patterns](#3-traditional-incremental-patterns)
+4. [is_incremental() Block Patterns](#4-is_incremental-block-patterns)
+5. [Full Refresh Management](#5-full-refresh-management)
+6. [Snowflake Performance](#6-snowflake-performance)
+7. [BigQuery Performance](#7-bigquery-performance)
+8. [Query Optimization](#8-query-optimization)
+9. [Cost Monitoring](#9-cost-monitoring)
+
+---
+
+## 1. Incremental Strategy Decision Matrix
+
+| Strategy | How It Works | Best For | Snowflake | BigQuery |
+|----------|-------------|----------|-----------|----------|
+| `microbatch` (1.9+) | Process time-based batches independently | Event/time-series data | Yes | Yes |
+| `merge` | MERGE statement with unique_key | Most use cases, upserts | Yes (default) | Yes (default) |
+| `delete+insert` | Delete matching rows, then insert | When merge is expensive | Yes | No |
+| `insert_overwrite` | Replace entire partitions | Partition-aligned event data | No | Yes |
+| `append` | Insert only, no updates | Immutable event logs | Yes | Yes |
+
+### Decision Flowchart
+
+```
+Is the data time-series or event-based?
+├── YES → Do rows ever get updated after initial insert?
+│   ├── NO → Is the table partitioned by date?
+│   │   ├── YES (BigQuery) → insert_overwrite
+│   │   ├── YES (Snowflake) → microbatch (1.9+) or append
+│   │   └── NO → append
+│   └── YES → Is dbt 1.9+ available?
+│       ├── YES → microbatch (preferred)
+│       └── NO → merge with lookback window
+├── NO → Does the source have a reliable updated_at column?
+│   ├── YES → merge with updated_at filter
+│   └── NO → Does the table have a unique key?
+│       ├── YES (Snowflake) → delete+insert
+│       ├── YES (BigQuery) → merge
+│       └── NO → append (with deduplication downstream)
+```
+
+### Strategy Comparison
+
+| Criteria | microbatch | merge | delete+insert | insert_overwrite | append |
+|----------|-----------|-------|---------------|------------------|--------|
+| Handles late-arriving data | Built-in | Manual lookback | Manual lookback | By partition | No |
+| Supports updates | Yes (with unique_key) | Yes | Yes | Partition-level | No |
+| Requires unique_key | Optional | Yes | Yes | No | No |
+| Partial retry on failure | Yes | No | No | No | No |
+| Compute cost | Low (parallel batches) | Medium | Medium | Low | Lowest |
+| Complexity | Low | Medium | Medium | Low | Lowest |
+
+---
+
+## 2. Microbatch Deep Dive (dbt 1.9+)
+
+Microbatch is a first-class incremental strategy that processes data in discrete time-based batches. Each batch runs independently, enabling parallel execution and targeted retries.
+
+### How Microbatch Works
+
+```
+Source data (30 days)
+    ↓
+dbt splits into batches (e.g., 1 batch per day)
+    ↓
+┌─────────┬─────────┬─────────┬─────────┐
+│ Day 1   │ Day 2   │ Day 3   │ ... N   │  ← Each batch runs independently
+└─────────┴─────────┴─────────┴─────────┘
+    ↓
+Failed batches retry without re-running successful ones
+```
+
+### Configuration
+
+| Config Key | Required | Description |
+|-----------|----------|-------------|
+| `incremental_strategy` | Yes | Set to `'microbatch'` |
+| `event_time` | Yes | Timestamp column for batch slicing |
+| `begin` | Yes | Earliest date to process (ISO format) |
+| `batch_size` | Yes | `'hour'`, `'day'`, `'month'`, or `'year'` |
+| `unique_key` | No | Column(s) for deduplication within batches |
+| `lookback` | No | Number of extra prior batches to reprocess (default: `0`) |
+
+### Complete Model Example
+
+```sql
+-- fct_app_events.sql
+-- Microbatch: dbt handles time filtering automatically.
+-- No {% if is_incremental() %} block needed.
+
+{{ config(
+    materialized='incremental',
+    incremental_strategy='microbatch',
+    event_time='event_occurred_at',
+    begin='2023-01-01',
+    batch_size='day',
+    unique_key='event_id'
+) }}
+
+select
+    event_id,
+    user_id,
+    event_type,
+    event_occurred_at,
+    event_payload
+from {{ ref('stg_app__events') }}
+```
+
+### Key Advantage: No is_incremental() Block
+
+With microbatch, dbt automatically filters each batch by `event_time`. Write the model as if processing all data -- dbt handles the windowing.
+
+```sql
+-- DO: Write clean SQL, let microbatch handle filtering
+{{ config(
+    materialized='incremental',
+    incremental_strategy='microbatch',
+    event_time='event_occurred_at',
+    begin='2023-01-01',
+    batch_size='day'
+) }}
+
+select
+    event_id,
+    user_id,
+    event_type,
+    event_occurred_at
+from {{ ref('stg_app__events') }}
+-- No {% if is_incremental() %} needed
+
+-- DON'T: Add manual filtering on top of microbatch
+{{ config(
+    materialized='incremental',
+    incremental_strategy='microbatch',
+    event_time='event_occurred_at',
+    begin='2023-01-01',
+    batch_size='day'
+) }}
+
+select *
+from {{ ref('stg_app__events') }}
+{% if is_incremental() %}
+where event_occurred_at > (select max(event_occurred_at) from {{ this }})
+{% endif %}
+-- Redundant: microbatch already filters by event_time
+```
+
+### Parallel Batch Execution
+
+Microbatch processes batches independently. On supported adapters, batches execute in parallel, reducing wall-clock time for large backfills.
+
+```bash
+# First run: processes all batches from begin date to today
+dbt run -s fct_app_events
+
+# Subsequent runs: processes only the latest batch(es)
+dbt run -s fct_app_events
+```
+
+### Retry Failed Batches
+
+If a run fails partway through, `dbt retry` re-runs only the failed batches:
+
+```bash
+# Run processes 30 batches, 3 fail
+dbt run -s fct_app_events
+
+# Retry re-runs only the 3 failed batches
+dbt retry
+```
+
+### Targeted Backfills
+
+Use `--event-time-start` and `--event-time-end` to reprocess a specific time range without touching other data:
+
+```bash
+# Reprocess a specific date range (e.g., data correction)
+dbt run -s fct_app_events --event-time-start 2024-03-01 --event-time-end 2024-03-15
+
+# Reprocess a single day
+dbt run -s fct_app_events --event-time-start 2024-06-15 --event-time-end 2024-06-16
+```
+
+### Lookback for Late-Arriving Data
+
+Set `lookback` to reprocess prior batches and capture late-arriving records:
+
+```sql
+{{ config(
+    materialized='incremental',
+    incremental_strategy='microbatch',
+    event_time='event_occurred_at',
+    begin='2023-01-01',
+    batch_size='day',
+    unique_key='event_id',
+    lookback=3              -- Reprocess 3 prior days each run
+) }}
+
+select
+    event_id,
+    user_id,
+    event_type,
+    event_occurred_at
+from {{ ref('stg_app__events') }}
+```
+
+### Batch Size Selection
+
+| Batch Size | Use When | Typical Volume |
+|-----------|----------|----------------|
+| `hour` | High-volume streams, near-real-time | > 10M rows/day |
+| `day` | Standard event data (most common) | 100K - 10M rows/day |
+| `month` | Low-volume or slowly changing data | < 100K rows/day |
+| `year` | Historical backfill of sparse data | Rarely used in production |
+
+---
+
+## 3. Traditional Incremental Patterns
+
+### Merge (Default Strategy)
+
+Use merge for models that require upserts -- inserting new rows and updating existing ones based on a unique key.
+
+```sql
+-- fct_orders.sql
+{{ config(
+    materialized='incremental',
+    unique_key='order_id',
+    on_schema_change='append_new_columns'
+) }}
+
+select
+    order_id,
+    customer_id,
+    order_status,
+    order_total,
+    updated_at
+from {{ ref('stg_shopify__orders') }}
+{% if is_incremental() %}
+where updated_at > (select max(updated_at) from {{ this }})
+{% endif %}
+```
+
+**Snowflake compiled SQL (simplified):**
+
+```sql
+merge into analytics.fct_orders as target
+using (
+    select order_id, customer_id, order_status, order_total, updated_at
+    from analytics.stg_shopify__orders
+    where updated_at > (select max(updated_at) from analytics.fct_orders)
+) as source
+on target.order_id = source.order_id
+when matched then update set
+    customer_id = source.customer_id,
+    order_status = source.order_status,
+    order_total = source.order_total,
+    updated_at = source.updated_at
+when not matched then insert
+    (order_id, customer_id, order_status, order_total, updated_at)
+    values (source.order_id, source.customer_id, source.order_status,
+            source.order_total, source.updated_at);
+```
+
+### Compound Unique Key
+
+Use a list when a single column does not uniquely identify rows:
+
+```sql
+{{ config(
+    materialized='incremental',
+    unique_key=['order_id', 'line_item_id'],
+    on_schema_change='append_new_columns'
+) }}
+
+select
+    order_id,
+    line_item_id,
+    product_id,
+    quantity,
+    unit_price,
+    updated_at
+from {{ ref('stg_shopify__order_line_items') }}
+{% if is_incremental() %}
+where updated_at > (select max(updated_at) from {{ this }})
+{% endif %}
+```
+
+### Delete+Insert (Snowflake Only)
+
+Use delete+insert when merge performance degrades on large tables or when the merge statement becomes expensive due to wide tables.
+
+```sql
+-- fct_order_events.sql (Snowflake)
+{{ config(
+    materialized='incremental',
+    incremental_strategy='delete+insert',
+    unique_key='event_id'
+) }}
+
+select
+    event_id,
+    order_id,
+    event_type,
+    event_payload,
+    created_at
+from {{ ref('stg_shopify__order_events') }}
+{% if is_incremental() %}
+where created_at > (select max(created_at) from {{ this }})
+{% endif %}
+```
+
+### Insert Overwrite (BigQuery Only)
+
+Use insert_overwrite for partition-aligned event data. Replaces entire partitions rather than merging individual rows.
+
+```sql
+-- fct_page_views.sql (BigQuery)
+{{ config(
+    materialized='incremental',
+    incremental_strategy='insert_overwrite',
+    partition_by={
+        "field": "page_view_date",
+        "data_type": "date",
+        "granularity": "day"
+    }
+) }}
+
+select
+    page_view_id,
+    user_id,
+    page_url,
+    referrer_url,
+    cast(page_view_at as date) as page_view_date,
+    page_view_at
+from {{ ref('stg_web__page_views') }}
+
+-- BigQuery automatically determines which partitions to overwrite
+-- based on the data returned by this query
+```
+
+**With static partitions for controlled overwrites:**
+
+```sql
+{{ config(
+    materialized='incremental',
+    incremental_strategy='insert_overwrite',
+    partition_by={
+        "field": "page_view_date",
+        "data_type": "date",
+        "granularity": "day",
+        "copy_partitions": true
+    },
+    partitions=["'2024-01-01'", "'2024-01-02'", "'2024-01-03'"]
+) }}
+```
+
+### Append (All Warehouses)
+
+Use append for immutable event streams where rows are never updated.
+
+```sql
+-- fct_clickstream.sql
+{{ config(
+    materialized='incremental',
+    incremental_strategy='append'
+) }}
+
+select
+    click_id,
+    session_id,
+    user_id,
+    element_id,
+    page_url,
+    clicked_at
+from {{ ref('stg_analytics__clicks') }}
+{% if is_incremental() %}
+where clicked_at > (select max(clicked_at) from {{ this }})
+{% endif %}
+
+-- No unique_key: rows are never updated or deduplicated
+-- If duplicates are possible, handle deduplication in a downstream model
+```
+
+---
+
+## 4. is_incremental() Block Patterns
+
+### Basic High-Watermark Pattern
+
+The most common approach -- select rows newer than the most recent row already loaded:
+
+```sql
+{% if is_incremental() %}
+where updated_at > (select max(updated_at) from {{ this }})
+{% endif %}
+```
+
+### Lookback Window for Late-Arriving Data
+
+Add a lookback buffer to capture records that arrive after their event timestamp:
+
+```sql
+-- 3-hour lookback: reprocess recent data each run
+{% if is_incremental() %}
+where event_at > (
+    select dateadd(hour, -3, max(event_at)) from {{ this }}
+)
+{% endif %}
+```
+
+```sql
+-- BigQuery equivalent
+{% if is_incremental() %}
+where event_at > (
+    select timestamp_sub(max(event_at), interval 3 hour) from {{ this }}
+)
+{% endif %}
+```
+
+### Multiple Conditions Pattern
+
+Combine the incremental filter with business logic filters:
+
+```sql
+{% if is_incremental() %}
+where
+    updated_at > (select max(updated_at) from {{ this }})
+    and order_status != 'draft'              -- Business filter
+    and _fivetran_deleted = false             -- Soft-delete filter
+{% endif %}
+```
+
+### Partition-Aware Filter (BigQuery)
+
+Filter on the partition column directly for partition pruning:
+
+```sql
+{% if is_incremental() %}
+where
+    date(event_at) >= (
+        select date_sub(max(date(event_at)), interval 1 day)
+        from {{ this }}
+    )
+{% endif %}
+```
+
+### Anti-Pattern: Overly Complex is_incremental() Blocks
+
+```sql
+-- DON'T: Complex multi-step logic inside is_incremental()
+{% if is_incremental() %}
+    {% set max_ts_query %}
+        select max(updated_at) from {{ this }}
+    {% endset %}
+    {% set max_ts = run_query(max_ts_query).columns[0][0] %}
+    {% if max_ts is none %}
+        where true
+    {% else %}
+        where updated_at > '{{ max_ts }}'
+              and category in (
+                  select distinct category
+                  from {{ source('raw', 'categories') }}
+                  where is_active = true
+              )
+    {% endif %}
+{% endif %}
+
+-- DO: Use microbatch instead for time-based processing,
+-- or simplify the filter to a single high-watermark comparison
+{% if is_incremental() %}
+where updated_at > (select max(updated_at) from {{ this }})
+{% endif %}
+```
+
+### When is_incremental() Returns True
+
+`is_incremental()` returns `true` only when ALL of these conditions are met:
+
+1. The model is materialized as `incremental`
+2. The target table already exists in the warehouse
+3. The run is NOT a `--full-refresh` run
+4. The run is NOT the first run (table must exist)
+
+---
+
+## 5. Full Refresh Management
+
+### When to Force a Full Refresh
+
+```bash
+# Rebuild a single model from scratch
+dbt run --full-refresh -s fct_orders
+
+# Rebuild a model and all its downstream dependents
+dbt run --full-refresh -s fct_orders+
+
+# Rebuild all incremental models
+dbt run --full-refresh -s config.materialized:incremental
+```
+
+**Trigger a full refresh when:**
+
+| Scenario | Why |
+|----------|-----|
+| Schema change (column added/removed) | Incremental may miss new columns |
+| Logic change in the model | Historical data needs reprocessing |
+| Data quality issue discovered | Corrupted incremental state |
+| Source data was reloaded | Upstream data changed retroactively |
+| Switching incremental strategies | New strategy needs clean table |
+
+### on_schema_change Options
+
+| Setting | Behavior | Use When |
+|---------|----------|----------|
+| `ignore` (default) | Silently skip new columns | Schema is stable, no changes expected |
+| `append_new_columns` | Add new columns (nulls for existing rows) | Source adds columns over time |
+| `sync_all_columns` | Add new columns, remove dropped columns | Schema must match exactly |
+| `fail` | Raise an error on any schema change | Strict CI environments |
+
+```sql
+-- Recommended for most incremental models
+{{ config(
+    materialized='incremental',
+    unique_key='order_id',
+    on_schema_change='append_new_columns'    -- Safe default for evolving sources
+) }}
+```
+
+### on_schema_change Decision Table
+
+| Scenario | Recommended Setting | Rationale |
+|----------|-------------------|-----------|
+| Stable source, production | `ignore` | No schema changes expected |
+| Evolving source (e.g., Fivetran) | `append_new_columns` | New columns added without breaking |
+| Strict data contract | `fail` | Force explicit schema management |
+| Development/experimentation | `sync_all_columns` | Keep schema in sync during iteration |
+| Columns may be dropped | `sync_all_columns` | Remove orphaned columns |
+
+### Scheduling Full Refreshes
+
+Build periodic full refreshes into CI/CD to prevent incremental drift:
+
+```yaml
+# dbt Cloud job configuration (conceptual)
+# Weekly full refresh for all incremental models
+- name: "Weekly Full Refresh"
+  schedule: "0 2 * * 0"                     # Sunday 2 AM
+  command: "dbt run --full-refresh -s config.materialized:incremental"
+
+# Daily incremental run
+- name: "Daily Incremental"
+  schedule: "0 6 * * *"                     # Daily 6 AM
+  command: "dbt run"
+```
+
+```yaml
+# GitHub Actions example
+name: Weekly Full Refresh
+on:
+  schedule:
+    - cron: '0 2 * * 0'
+jobs:
+  full_refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run full refresh
+        run: dbt run --full-refresh -s config.materialized:incremental
+        env:
+          DBT_PROFILES_DIR: ./
+```
+
+---
+
+## 6. Snowflake Performance
+
+### Cluster Keys
+
+Snowflake micro-partitions are created automatically. Add explicit cluster keys when query patterns consistently filter on specific columns and table scans are slow.
+
+```sql
+-- Add cluster keys for large, frequently filtered tables
+{{ config(
+    materialized='incremental',
+    unique_key='event_id',
+    cluster_by=['event_date', 'user_id']    -- Most-filtered columns first
+) }}
+```
+
+**When to use cluster keys:**
+
+| Condition | Action |
+|-----------|--------|
+| Table < 1 TB | Skip clustering (micro-partitions sufficient) |
+| Table > 1 TB with slow filtered queries | Add cluster keys on filter columns |
+| High-cardinality filter column | Good candidate (e.g., user_id, date) |
+| Low-cardinality column only | Poor candidate (e.g., boolean status) |
+| Frequent range scans | Cluster on the range column (e.g., date) |
+
+**Monitor clustering effectiveness:**
+
+```sql
+-- Check clustering depth (lower is better)
+select system$clustering_information('analytics.fct_events', '(event_date, user_id)');
+
+-- Monitor automatic reclustering credits
+select *
+from snowflake.account_usage.automatic_clustering_history
+where table_name = 'FCT_EVENTS'
+order by start_time desc
+limit 10;
+```
+
+### Transient Tables
+
+Skip Snowflake's 7-day fail-safe period for tables that can be rebuilt from source. Saves significant storage cost on large tables.
+
+```sql
+-- Transient: no fail-safe, reducible time travel (0-1 day)
+{{ config(
+    materialized='incremental',
+    unique_key='event_id',
+    transient=true                           -- Skip fail-safe, save storage
+) }}
+```
+
+| Table Type | Time Travel | Fail-Safe | Storage Cost | Use For |
+|-----------|-------------|-----------|--------------|---------|
+| Permanent (default) | 0-90 days | 7 days | Highest | Critical business data |
+| Transient | 0-1 day | None | Lower | Rebuildable dbt models |
+
+```sql
+-- Set transient as default for all models in dbt_project.yml
+-- dbt_project.yml
+-- models:
+--   my_project:
+--     marts:
+--       +transient: true
+```
+
+### Dynamic Tables
+
+Snowflake Dynamic Tables automate incremental refreshes at the warehouse level. Use when the transformation is simple and near-real-time freshness is needed.
+
+```sql
+-- Dynamic table: Snowflake manages refresh automatically
+{{ config(
+    materialized='dynamic_table',
+    target_lag='5 minutes',                  -- Snowflake refreshes within 5 min of source change
+    snowflake_warehouse='transformations_wh'
+) }}
+
+select
+    order_id,
+    customer_id,
+    order_total,
+    updated_at
+from {{ ref('stg_shopify__orders') }}
+```
+
+| Feature | dbt Incremental | Snowflake Dynamic Table |
+|---------|----------------|------------------------|
+| Refresh trigger | dbt run (scheduled) | Automatic (lag-based) |
+| Freshness | Minutes to hours (job interval) | Seconds to minutes |
+| Complex transforms | Full Jinja/SQL support | SQL only (no Jinja at runtime) |
+| Cost control | Warehouse sizing + schedule | Dedicated warehouse + lag setting |
+| Retry/backfill | Manual or dbt retry | Automatic |
+
+**Use Dynamic Tables when:**
+- Near-real-time freshness required (< 5 min lag)
+- Transformation is straightforward SQL
+- Upstream tables are in the same Snowflake account
+
+**Use dbt incremental when:**
+- Complex Jinja logic or macros involved
+- Cross-database sources
+- Fine-grained control over refresh logic
+- Cost-sensitive batch workloads
+
+### Warehouse Sizing
+
+| Environment | Recommended Size | Rationale |
+|-------------|-----------------|-----------|
+| Local development | X-SMALL | Minimize cost for ad-hoc queries |
+| CI/CD (Slim CI) | SMALL | Fast enough for modified models |
+| CI/CD (Full build) | MEDIUM | Balance speed and cost |
+| Production (light) | SMALL - MEDIUM | Standard scheduled runs |
+| Production (heavy) | LARGE+ | High-volume incremental models |
+
+```sql
+-- Set warehouse per model or folder in dbt_project.yml
+-- models:
+--   my_project:
+--     staging:
+--       +snowflake_warehouse: transformations_wh_xs
+--     marts:
+--       +snowflake_warehouse: transformations_wh_m
+```
+
+```sql
+-- Or per-model override for expensive models
+{{ config(
+    materialized='incremental',
+    unique_key='event_id',
+    snowflake_warehouse='transformations_wh_lg'
+) }}
+```
+
+### Zero-Copy Cloning for Dev/Test
+
+Clone production databases for development without duplicating storage:
+
+```sql
+-- Create a dev clone of production (zero storage cost until data diverges)
+create database analytics_dev clone analytics;
+
+-- In profiles.yml, point dev target to cloned database
+-- profiles.yml:
+--   my_project:
+--     target: dev
+--     outputs:
+--       dev:
+--         type: snowflake
+--         database: analytics_dev
+```
+
+### Query Profiling
+
+```sql
+-- Find slowest dbt models by execution time
+select
+    query_text,
+    total_elapsed_time / 1000 as elapsed_seconds,
+    bytes_scanned / (1024*1024*1024) as gb_scanned,
+    rows_produced,
+    warehouse_name
+from snowflake.account_usage.query_history
+where query_tag like '%dbt%'
+    and start_time > dateadd(day, -7, current_timestamp())
+order by total_elapsed_time desc
+limit 20;
+
+-- Warehouse credit usage by model tag
+select
+    query_tag,
+    count(*) as query_count,
+    sum(total_elapsed_time) / 1000 as total_seconds,
+    sum(credits_used_cloud_services) as credits_used
+from snowflake.account_usage.query_history
+where query_tag like '%dbt%'
+    and start_time > dateadd(day, -7, current_timestamp())
+group by query_tag
+order by credits_used desc;
+```
+
+---
+
+## 7. BigQuery Performance
+
+### Partition Strategies
+
+Every large BigQuery table should be partitioned. Partitioning limits the amount of data scanned per query, directly reducing cost.
+
+| Partition Type | Config | Use When |
+|---------------|--------|----------|
+| Date/Timestamp column | `"data_type": "date"` or `"timestamp"` | Table has a date/time column |
+| Ingestion time | `"data_type": "timestamp", "field": "_PARTITIONTIME"` | No reliable date column |
+| Integer range | `"data_type": "int64", "range": {...}` | Partition by numeric ID range |
+
+### Partition Configuration
+
+```sql
+-- Date partitioning (most common)
+{{ config(
+    materialized='incremental',
+    unique_key='order_id',
+    partition_by={
+        "field": "order_date",
+        "data_type": "date",
+        "granularity": "day"                 -- day, month, or year
+    }
+) }}
+
+-- Timestamp partitioning (hour-level granularity)
+{{ config(
+    materialized='incremental',
+    unique_key='event_id',
+    partition_by={
+        "field": "event_at",
+        "data_type": "timestamp",
+        "granularity": "hour"
+    }
+) }}
+
+-- Integer range partitioning
+{{ config(
+    materialized='incremental',
+    unique_key='user_id',
+    partition_by={
+        "field": "user_id",
+        "data_type": "int64",
+        "range": {
+            "start": 0,
+            "end": 100000000,
+            "interval": 1000
+        }
+    }
+) }}
+```
+
+### Partition with copy_partitions
+
+Use `copy_partitions: true` with `insert_overwrite` to avoid unnecessary data movement:
+
+```sql
+{{ config(
+    materialized='incremental',
+    incremental_strategy='insert_overwrite',
+    partition_by={
+        "field": "event_date",
+        "data_type": "date",
+        "granularity": "day",
+        "copy_partitions": true              -- Copies partitions directly (faster)
+    }
+) }}
+```
+
+### Cluster Columns
+
+Add up to 4 cluster columns to optimize query filtering within partitions. Choose high-cardinality columns that appear in WHERE and JOIN clauses.
+
+```sql
+{{ config(
+    materialized='incremental',
+    unique_key='event_id',
+    partition_by={
+        "field": "event_date",
+        "data_type": "date"
+    },
+    cluster_by=['user_id', 'event_type']     -- Up to 4 columns
+) }}
+```
+
+**Cluster column selection:**
+
+| Priority | Column Type | Example |
+|----------|------------|---------|
+| 1st | Most common filter column | `user_id` |
+| 2nd | Second most common filter | `event_type` |
+| 3rd | Join key | `product_id` |
+| 4th | Secondary filter | `region` |
+
+### require_partition_filter
+
+Prevent accidental full table scans by requiring a partition filter in every query:
+
+```sql
+{{ config(
+    materialized='incremental',
+    unique_key='event_id',
+    partition_by={
+        "field": "event_date",
+        "data_type": "date"
+    },
+    require_partition_filter=true             -- Queries MUST filter on event_date
+) }}
+```
+
+**When to use:**
+
+| Scenario | require_partition_filter |
+|----------|------------------------|
+| Large fact tables (> 1 TB) | Yes -- prevent expensive scans |
+| Frequently queried by analysts | Yes -- enforce cost discipline |
+| Tables only accessed by dbt downstream | No -- dbt generates correct filters |
+| Small dimension tables | No -- full scan is cheap |
+
+### maximum_bytes_billed
+
+Set a safety limit to kill queries that scan too much data:
+
+```sql
+-- Per-model safety limit
+{{ config(
+    materialized='incremental',
+    unique_key='event_id',
+    maximum_bytes_billed=1000000000000       -- 1 TB limit
+) }}
+```
+
+### Slot Management
+
+| Pricing Model | How It Works | Best For |
+|--------------|-------------|----------|
+| On-demand | Pay per TB scanned | Unpredictable workloads |
+| Editions (Standard/Enterprise) | Autoscaling reservations | Predictable dbt workloads |
+
+**Autoscaling reservations for dbt:**
+
+```
+Baseline slots: 100 (always available)
+Autoscale max:  400 (scales up for dbt runs)
+Idle scale-down: 0  (no cost when idle)
+```
+
+### Bytes Billed Monitoring
+
+```sql
+-- Top 20 most expensive dbt queries (last 7 days)
+select
+    job_id,
+    user_email,
+    query,
+    total_bytes_billed / (1024*1024*1024) as gb_billed,
+    total_bytes_billed / (1024*1024*1024*1024) * 6.25 as estimated_cost_usd,
+    creation_time,
+    total_slot_ms / 1000 as slot_seconds
+from `region-us`.INFORMATION_SCHEMA.JOBS
+where creation_time > timestamp_sub(current_timestamp(), interval 7 day)
+    and statement_type != 'SCRIPT'
+    and job_type = 'QUERY'
+    and state = 'DONE'
+order by total_bytes_billed desc
+limit 20;
+
+-- Daily cost trend for dbt jobs
+select
+    date(creation_time) as query_date,
+    count(*) as query_count,
+    sum(total_bytes_billed) / (1024*1024*1024*1024) as tb_billed,
+    sum(total_bytes_billed) / (1024*1024*1024*1024) * 6.25 as estimated_cost_usd
+from `region-us`.INFORMATION_SCHEMA.JOBS
+where creation_time > timestamp_sub(current_timestamp(), interval 30 day)
+    and user_email like '%dbt%'              -- Filter for dbt service account
+    and state = 'DONE'
+group by query_date
+order by query_date desc;
+```
+
+---
+
+## 8. Query Optimization
+
+### CTE Behavior Differences
+
+| Warehouse | CTE Behavior | Implication |
+|-----------|-------------|-------------|
+| Snowflake | May materialize CTEs as temp results | Repeated CTE references may re-execute; use intermediate models for heavy CTEs |
+| BigQuery | Inlines CTEs into the query plan | Large CTEs referenced multiple times increase bytes scanned |
+
+```sql
+-- DO: Extract heavily-reused CTEs into their own models
+-- models/intermediate/int_user_activity_daily.sql
+{{ config(materialized='ephemeral') }}
+
+select
+    user_id,
+    date(event_at) as activity_date,
+    count(*) as event_count
+from {{ ref('stg_app__events') }}
+group by 1, 2
+
+-- Then reference once in downstream models
+-- models/marts/fct_user_engagement.sql
+select * from {{ ref('int_user_activity_daily') }}
+where event_count > 5
+
+-- DON'T: Define a heavy CTE and reference it 3+ times in the same model
+```
+
+### Column Pruning
+
+Select only the columns needed. In BigQuery, every column scanned adds to bytes billed.
+
+```sql
+-- DO: Select specific columns
+select
+    order_id,
+    customer_id,
+    order_total,
+    order_date
+from {{ ref('stg_shopify__orders') }}
+
+-- DON'T: Select all columns in marts or downstream models
+select *
+from {{ ref('stg_shopify__orders') }}
+-- In BigQuery, this scans ALL columns (including large payload fields)
+-- In Snowflake, this still transfers unnecessary data
+```
+
+### Join Optimization
+
+Filter before joining to reduce the data volume in the join operation:
+
+```sql
+-- DO: Filter early, then join
+with recent_orders as (
+    select order_id, customer_id, order_total
+    from {{ ref('stg_shopify__orders') }}
+    where order_date >= '2024-01-01'         -- Filter before join
+),
+
+payments as (
+    select order_id, payment_method, amount
+    from {{ ref('stg_stripe__payments') }}
+    where payment_status = 'completed'       -- Filter before join
+)
+
+select
+    o.order_id,
+    o.customer_id,
+    o.order_total,
+    p.payment_method,
+    p.amount
+from recent_orders o
+left join payments p on o.order_id = p.order_id
+
+-- DON'T: Join full tables then filter
+select
+    o.order_id,
+    o.customer_id,
+    o.order_total,
+    p.payment_method,
+    p.amount
+from {{ ref('stg_shopify__orders') }} o
+left join {{ ref('stg_stripe__payments') }} p on o.order_id = p.order_id
+where o.order_date >= '2024-01-01'
+    and p.payment_status = 'completed'
+```
+
+### Window Function Optimization
+
+Partition window functions by high-cardinality columns to limit the sort/partition scope:
+
+```sql
+-- DO: Partition by a high-cardinality key
+select
+    user_id,
+    event_at,
+    row_number() over (
+        partition by user_id                 -- High cardinality, small partitions
+        order by event_at desc
+    ) as event_rank
+from {{ ref('stg_app__events') }}
+
+-- DON'T: Partition by low-cardinality or no partition at all
+select
+    user_id,
+    event_at,
+    row_number() over (
+        order by event_at desc               -- Sorts entire table, very expensive
+    ) as event_rank
+from {{ ref('stg_app__events') }}
+```
+
+### Avoid SELECT * in Downstream Models
+
+Using `SELECT *` in models that depend on incremental models breaks `on_schema_change` behavior and causes unexpected failures:
+
+```sql
+-- DON'T: SELECT * from an incremental model
+select * from {{ ref('fct_orders') }}
+-- If fct_orders adds a column, this model silently picks it up
+-- If fct_orders drops a column, this model breaks
+
+-- DO: Explicitly list columns
+select
+    order_id,
+    customer_id,
+    order_total,
+    order_date
+from {{ ref('fct_orders') }}
+```
+
+---
+
+## 9. Cost Monitoring
+
+### Snowflake Credit Monitoring
+
+```sql
+-- Daily credit usage by warehouse (last 30 days)
+select
+    warehouse_name,
+    date(start_time) as usage_date,
+    sum(credits_used) as total_credits,
+    sum(credits_used) * 3.00 as estimated_cost_usd  -- Adjust rate per contract
+from snowflake.account_usage.warehouse_metering_history
+where start_time > dateadd(day, -30, current_timestamp())
+group by warehouse_name, usage_date
+order by usage_date desc, total_credits desc;
+
+-- Warehouse utilization (idle vs active time)
+select
+    warehouse_name,
+    sum(credits_used) as credits_used,
+    sum(credits_used_compute) as compute_credits,
+    sum(credits_used_cloud_services) as cloud_credits,
+    avg(avg_running) as avg_concurrent_queries,
+    avg(avg_queued_load) as avg_queued_queries
+from snowflake.account_usage.warehouse_metering_history
+where start_time > dateadd(day, -7, current_timestamp())
+group by warehouse_name
+order by credits_used desc;
+```
+
+### BigQuery Cost Monitoring
+
+```sql
+-- Monthly cost by dataset (proxy for dbt layer)
+select
+    date_trunc(creation_time, month) as month,
+    split(destination_table.dataset_id, '_')[safe_offset(0)] as layer,
+    count(*) as query_count,
+    sum(total_bytes_billed) / power(1024, 4) as tb_billed,
+    sum(total_bytes_billed) / power(1024, 4) * 6.25 as estimated_cost_usd
+from `region-us`.INFORMATION_SCHEMA.JOBS
+where creation_time > timestamp_sub(current_timestamp(), interval 90 day)
+    and job_type = 'QUERY'
+    and state = 'DONE'
+group by month, layer
+order by month desc, estimated_cost_usd desc;
+
+-- Identify models causing slot contention
+select
+    query,
+    total_slot_ms / 1000 as slot_seconds,
+    total_bytes_billed / (1024*1024*1024) as gb_billed,
+    creation_time
+from `region-us`.INFORMATION_SCHEMA.JOBS
+where creation_time > timestamp_sub(current_timestamp(), interval 7 day)
+    and total_slot_ms > 600000               -- > 10 slot-minutes
+    and state = 'DONE'
+order by total_slot_ms desc
+limit 20;
+```
+
+### Alerting Thresholds
+
+| Metric | Warning | Critical | Action |
+|--------|---------|----------|--------|
+| **Snowflake daily credits** | > 120% of baseline | > 200% of baseline | Investigate warehouse usage |
+| **Snowflake query queue** | > 5 min avg | > 15 min avg | Upsize warehouse or split workloads |
+| **BigQuery daily TB billed** | > 120% of baseline | > 200% of baseline | Check for missing partition filters |
+| **BigQuery slot utilization** | > 80% sustained | > 95% sustained | Add autoscaling capacity |
+| **dbt model runtime** | > 2x historical avg | > 5x historical avg | Investigate data volume spike |
+| **Full refresh cost** | > 3x incremental cost | > 10x incremental cost | Optimize or split model |
+
+### dbt Model-Level Cost Tagging
+
+Tag models to attribute costs back to business domains:
+
+```yaml
+# dbt_project.yml
+models:
+  my_project:
+    staging:
+      +tags: ['staging', 'low-cost']
+    marts:
+      finance:
+        +tags: ['marts', 'finance']
+      marketing:
+        +tags: ['marts', 'marketing']
+```
+
+```sql
+-- Snowflake: Set query tags for cost attribution
+-- In a macro (macros/set_query_tag.sql):
+{% macro set_query_tag() %}
+    {% set tag = "dbt_" ~ this.schema ~ "_" ~ this.name %}
+    alter session set query_tag = '{{ tag }}';
+{% endmacro %}
+
+-- Use in on-run-start or as a pre-hook
+-- dbt_project.yml:
+-- on-run-start:
+--   - "{{ set_query_tag() }}"
+```
+
+### Cost Optimization Comparison
+
+| Technique | Snowflake Impact | BigQuery Impact |
+|-----------|-----------------|-----------------|
+| **Partitioning** | Automatic (micro-partitions); cluster keys for targeted pruning | Critical -- reduces bytes scanned per query |
+| **Clustering** | Reduces scan range on filtered queries | Reduces bytes scanned within partitions |
+| **Incremental models** | Reduces compute time (credits) | Reduces bytes scanned (cost) |
+| **Column pruning** | Minor -- columnar storage helps | Major -- directly reduces bytes billed |
+| **Transient tables** | Saves 7-day fail-safe storage cost | N/A |
+| **Warehouse auto-suspend** | Prevents idle credit burn | N/A (on-demand is per-query) |
+| **require_partition_filter** | N/A | Prevents accidental full scans |
+| **maximum_bytes_billed** | N/A | Kills runaway queries |
+| **Reservation autoscaling** | N/A | Controls slot cost with flex capacity |
+| **Ephemeral intermediate models** | Eliminates table storage and compute | Eliminates table storage and scan cost |
+| **Dynamic tables** | Offloads scheduling to Snowflake; cost depends on lag | N/A |
+| **Result caching** | Automatic for identical queries (free) | Automatic for identical queries (free) |
+
+---
+
+**Back to:** [Main Skill File](../SKILL.md)

--- a/skills/dbt-skill/references/jinja-macros-packages.md
+++ b/skills/dbt-skill/references/jinja-macros-packages.md
@@ -1,0 +1,1217 @@
+# Jinja, Macros & Packages
+
+> **Part of:** [dbt-skill](../SKILL.md)
+> **Purpose:** Jinja templating fundamentals, custom macro development, essential package ecosystem, warehouse-adaptive patterns, and debugging workflows
+
+This document provides detailed guidance on Jinja in dbt, writing and organizing macros, leveraging the package ecosystem, and debugging compiled SQL. For project structure and modeling methodology, see the [main skill file](../SKILL.md).
+
+---
+
+## Table of Contents
+
+1. [Jinja Fundamentals](#jinja-fundamentals)
+2. [Control Flow Patterns](#control-flow-patterns)
+3. [Writing Custom Macros](#writing-custom-macros)
+4. [Macro Organization](#macro-organization)
+5. [Essential Packages](#essential-packages)
+6. [Package Management](#package-management)
+7. [Common Macro Patterns](#common-macro-patterns)
+8. [Debugging Jinja](#debugging-jinja)
+
+---
+
+## Jinja Fundamentals
+
+### Three Tag Types
+
+| Tag | Syntax | Purpose | Compiles to SQL? |
+|-----|--------|---------|-----------------|
+| Expression | `{{ }}` | Output a value | Yes |
+| Statement | `{% %}` | Control flow, variable assignment | No (controls what SQL is generated) |
+| Comment | `{# #}` | Documentation, notes | No (stripped entirely) |
+
+### Expression Tags — `{{ }}`
+
+Output values into compiled SQL. Use for references, variables, and macro calls.
+
+```sql
+-- References
+select * from {{ ref('stg_shopify__orders') }}
+select * from {{ source('stripe', 'payments') }}
+
+-- Variables
+where order_date >= '{{ var("start_date") }}'
+
+-- Config
+{{ config(materialized='incremental', unique_key='order_id') }}
+
+-- Environment variables
+{% set api_schema = env_var('DBT_STRIPE_SCHEMA', 'stripe') %}
+```
+
+### Statement Tags — `{% %}`
+
+Control what SQL gets generated. Never appear in compiled output.
+
+```sql
+{% set payment_methods = ['credit_card', 'bank_transfer', 'gift_card'] %}
+
+{% if is_incremental() %}
+    where updated_at > (select max(updated_at) from {{ this }})
+{% endif %}
+
+{% for method in payment_methods %}
+    sum(case when payment_method = '{{ method }}' then amount_dollars else 0 end) as {{ method }}_amount
+    {%- if not loop.last %},{% endif %}
+{% endfor %}
+```
+
+### Comment Tags — `{# #}`
+
+Stripped during compilation. Use for Jinja-level documentation.
+
+```sql
+{# This comment will NOT appear in compiled SQL #}
+-- This SQL comment WILL appear in compiled SQL
+
+{# TODO: Replace with macro once dbt-utils supports this natively #}
+```
+
+### Whitespace Control
+
+Add a hyphen inside tags to strip whitespace on that side.
+
+```sql
+-- Without whitespace control (produces extra blank lines)
+{% if is_incremental() %}
+    where updated_at > (select max(updated_at) from {{ this }})
+{% endif %}
+
+-- With whitespace control (clean output)
+{%- if is_incremental() %}
+    where updated_at > (select max(updated_at) from {{ this }})
+{%- endif %}
+```
+
+| Syntax | Effect |
+|--------|--------|
+| `{%- ... %}` | Strip whitespace before the tag |
+| `{% ... -%}` | Strip whitespace after the tag |
+| `{%- ... -%}` | Strip whitespace on both sides |
+
+### dbt-Specific Context Objects
+
+| Object | Purpose | Example |
+|--------|---------|---------|
+| `ref()` | Reference another model | `{{ ref('stg_stripe__payments') }}` |
+| `source()` | Reference a source table | `{{ source('shopify', 'orders') }}` |
+| `config()` | Set model configuration | `{{ config(materialized='table') }}` |
+| `var()` | Access project variables | `{{ var('start_date', '2020-01-01') }}` |
+| `env_var()` | Read environment variables | `{{ env_var('DBT_TARGET', 'dev') }}` |
+| `this` | Current model relation | `{{ this }}` (in incremental models) |
+| `target` | Connection target info | `{{ target.name }}`, `{{ target.type }}` |
+| `is_incremental()` | Check if running incrementally | `{% if is_incremental() %}` |
+
+### Complete Example — All Three Tag Types
+
+```sql
+{# fct_orders.sql — Combines order and payment data into a single fact table #}
+
+{{ config(
+    materialized='incremental',
+    unique_key='order_id',
+    on_schema_change='append_new_columns'
+) }}
+
+{% set payment_methods = ['credit_card', 'bank_transfer', 'gift_card'] %}
+
+with orders as (
+    select * from {{ ref('stg_shopify__orders') }}
+    {%- if is_incremental() %}
+    where updated_at > (select max(updated_at) from {{ this }})
+    {%- endif %}
+),
+
+payments as (
+    select * from {{ ref('int_payments_pivoted') }}
+),
+
+final as (
+    select
+        orders.order_id,
+        orders.customer_id,
+        orders.order_date,
+        orders.order_status,
+        {% for method in payment_methods %}
+        payments.{{ method }}_amount
+        {%- if not loop.last %},{% endif %}
+        {% endfor %}
+    from orders
+    left join payments on orders.order_id = payments.order_id
+)
+
+select * from final
+```
+
+---
+
+## Control Flow Patterns
+
+### Environment-Specific Logic
+
+Use `target.name` to vary behavior across environments.
+
+```sql
+{{ config(
+    materialized='table',
+    pre_hook=[
+        "{{ 'alter warehouse analytics_wh set warehouse_size = xlarge' if target.name == 'prod' else '' }}"
+    ]
+) }}
+
+select *
+from {{ ref('stg_shopify__orders') }}
+{% if target.name == 'dev' %}
+    {# Limit data in dev for faster iteration #}
+    where order_date >= dateadd('month', -3, current_date)
+{% endif %}
+```
+
+### Incremental Filtering
+
+```sql
+{{ config(materialized='incremental', unique_key='order_id') }}
+
+select
+    order_id,
+    customer_id,
+    order_date,
+    total_amount,
+    updated_at
+
+from {{ ref('stg_shopify__orders') }}
+
+{% if is_incremental() %}
+    where updated_at > (select max(updated_at) from {{ this }})
+{% endif %}
+```
+
+### Dynamic Column Generation — Pivot Pattern
+
+Generate pivot columns from a list without repetitive SQL.
+
+```sql
+-- int_payments_pivoted.sql
+{% set payment_methods = dbt_utils.get_column_values(
+    table=ref('stg_stripe__payments'),
+    column='payment_method'
+) %}
+
+with payments as (
+    select * from {{ ref('stg_stripe__payments') }}
+),
+
+pivoted as (
+    select
+        order_id,
+        {% for method in payment_methods %}
+        sum(case when payment_method = '{{ method }}' then amount_dollars else 0 end) as {{ method }}_amount
+        {%- if not loop.last %},{% endif %}
+        {% endfor %}
+    from payments
+    where payment_status = 'completed'
+    group by order_id
+)
+
+select * from pivoted
+```
+
+### Conditional Warehouse-Specific SQL
+
+```sql
+-- Generate date truncation that works across warehouses
+{% macro trunc_date(date_column, granularity) %}
+    {% if target.type == 'snowflake' %}
+        date_trunc('{{ granularity }}', {{ date_column }})
+    {% elif target.type == 'bigquery' %}
+        date_trunc({{ date_column }}, {{ granularity }})
+    {% endif %}
+{% endmacro %}
+```
+
+### Loop Over Metrics to Aggregate
+
+```sql
+-- rpt_monthly_revenue.sql
+{% set metrics = [
+    {'column': 'total_amount', 'agg': 'sum', 'alias': 'total_revenue'},
+    {'column': 'order_id', 'agg': 'count', 'alias': 'total_orders'},
+    {'column': 'total_amount', 'agg': 'avg', 'alias': 'avg_order_value'},
+] %}
+
+select
+    date_trunc('month', order_date) as order_month,
+    {% for metric in metrics %}
+    {{ metric.agg }}({{ metric.column }}) as {{ metric.alias }}
+    {%- if not loop.last %},{% endif %}
+    {% endfor %}
+
+from {{ ref('fct_orders') }}
+group by 1
+order by 1
+```
+
+### Variable Assignment with `{% set %}`
+
+```sql
+{# Simple assignment #}
+{% set days_lookback = 90 %}
+
+{# List assignment #}
+{% set statuses = ['completed', 'refunded'] %}
+
+{# Query result assignment #}
+{% set max_date_query %}
+    select max(order_date) from {{ ref('fct_orders') }}
+{% endset %}
+{% set max_date = run_query(max_date_query).columns[0][0] %}
+
+{# Dictionary assignment #}
+{% set warehouse_sizes = {
+    'dev': 'xsmall',
+    'staging': 'small',
+    'prod': 'large'
+} %}
+```
+
+---
+
+## Writing Custom Macros
+
+### Definition Syntax
+
+```sql
+{# macros/utils/safe_divide.sql #}
+
+{% macro safe_divide(numerator, denominator, default=0) %}
+    {% if target.type == 'snowflake' %}
+        div0({{ numerator }}, {{ denominator }})
+    {% elif target.type == 'bigquery' %}
+        safe_divide({{ numerator }}, {{ denominator }})
+    {% else %}
+        case when {{ denominator }} != 0
+            then {{ numerator }}::float / {{ denominator }}
+            else {{ default }}
+        end
+    {% endif %}
+{% endmacro %}
+```
+
+### Return Values
+
+```sql
+{# Implicit return — the rendered template is the return value #}
+{% macro cents_to_dollars(column_name) %}
+    ({{ column_name }} / 100.0)
+{% endmacro %}
+
+{# Explicit return — use when computing a value, not generating SQL #}
+{% macro get_payment_methods() %}
+    {% set methods = ['credit_card', 'bank_transfer', 'gift_card'] %}
+    {% do return(methods) %}
+{% endmacro %}
+
+{# Usage of explicit return #}
+{% set payment_methods = get_payment_methods() %}
+{% for method in payment_methods %}
+    ...
+{% endfor %}
+```
+
+### File Location and Naming Convention
+
+```
+macros/
+├── utils/
+│   ├── safe_divide.sql          # Cross-warehouse safe division
+│   ├── cents_to_dollars.sql     # Currency conversion helper
+│   └── deduplicate.sql          # Row deduplication macro
+├── schema/
+│   ├── generate_schema_name.sql # Custom schema routing
+│   └── generate_alias_name.sql  # Custom table aliasing
+├── tests/
+│   ├── test_not_negative.sql    # Custom generic test
+│   └── test_row_count.sql       # Row count bounds test
+├── grants/
+│   └── grant_select.sql         # Post-hook grant management
+└── logging/
+    └── log_model_timing.sql     # Structured debug logging
+```
+
+### Calling Macros
+
+**In a model:**
+```sql
+-- models/marts/fct_orders.sql
+select
+    order_id,
+    {{ cents_to_dollars('amount_cents') }} as amount_dollars,
+    {{ safe_divide('discount_amount', 'subtotal_amount') }} as discount_rate
+from {{ ref('stg_stripe__payments') }}
+```
+
+**From the CLI:**
+```bash
+# Run a macro directly (useful for operational macros)
+dbt run-operation grant_select --args '{"role": "analytics_reader"}'
+
+# Run with named arguments
+dbt run-operation log_model_timing --args '{"model_name": "fct_orders"}'
+```
+
+### Warehouse-Adaptive Macros
+
+Use `target.type` to emit warehouse-specific SQL from a single macro.
+
+```sql
+{# macros/utils/safe_divide.sql #}
+
+{% macro safe_divide(numerator, denominator) %}
+    {% if target.type == 'snowflake' %}
+        div0({{ numerator }}, {{ denominator }})
+    {% elif target.type == 'bigquery' %}
+        safe_divide({{ numerator }}, {{ denominator }})
+    {% else %}
+        case when {{ denominator }} != 0
+            then {{ numerator }} / {{ denominator }}
+            else 0
+        end
+    {% endif %}
+{% endmacro %}
+```
+
+---
+
+## Macro Organization
+
+### Group by Purpose
+
+| Directory | Contents | Examples |
+|-----------|----------|----------|
+| `macros/utils/` | Reusable SQL helpers | `safe_divide`, `deduplicate`, `cents_to_dollars` |
+| `macros/schema/` | Schema/alias overrides | `generate_schema_name`, `generate_alias_name` |
+| `macros/tests/` | Custom generic tests | `test_not_negative`, `test_accepted_range` |
+| `macros/grants/` | Permission management | `grant_select`, `grant_usage` |
+| `macros/logging/` | Debug and observability | `log_model_timing`, `log_row_counts` |
+| `macros/staging/` | Staging helpers | `generate_base_model`, `standardize_timestamps` |
+
+### Document Macros
+
+```sql
+{# macros/utils/safe_divide.sql #}
+
+{% macro safe_divide(numerator, denominator) %}
+    {# Cross-warehouse safe division that returns 0 instead of dividing by zero.
+       Works on Snowflake (div0), BigQuery (safe_divide), and generic SQL.
+
+       Args:
+           numerator: column or expression for the numerator
+           denominator: column or expression for the denominator
+
+       Usage:
+           {{ safe_divide('revenue', 'total_orders') }}
+    #}
+    ...
+{% endmacro %}
+```
+
+Add corresponding `{% docs %}` blocks for the dbt docs site:
+
+```markdown
+{# in macros/utils/safe_divide.sql or a separate docs block file #}
+
+{% docs safe_divide %}
+Cross-warehouse safe division macro. Returns 0 when the denominator is zero.
+
+**Supported warehouses:** Snowflake, BigQuery, Postgres
+
+**Arguments:**
+- `numerator` — column or expression
+- `denominator` — column or expression
+
+**Example:**
+```sql
+select {{ safe_divide('revenue', 'total_orders') }} as avg_revenue_per_order
+```
+{% enddocs %}
+```
+
+### When to Extract vs Inline
+
+| Reuse Count | Complexity | Action | Rationale |
+|-------------|------------|--------|-----------|
+| 1 | Low | Inline | Extraction adds indirection for no benefit |
+| 1 | High | Extract | Improves readability of the model |
+| 2+ | Any | Extract to macro | DRY principle, single source of truth |
+| Cross-project | Any | Extract to package | Share via git or hub package |
+
+### Testing Macros with `dbt run-operation`
+
+```bash
+# Test a macro that generates SQL
+dbt run-operation safe_divide --args '{"numerator": "10", "denominator": "3"}'
+
+# Test a macro that returns a list
+dbt run-operation get_payment_methods
+
+# Test with --target to verify warehouse-specific branches
+dbt run-operation safe_divide --args '{"numerator": "10", "denominator": "0"}' --target prod
+```
+
+---
+
+## Essential Packages
+
+### Package Overview
+
+| Package | Category | Purpose | Install Priority |
+|---------|----------|---------|-----------------|
+| `dbt-utils` | Must-have | Cross-database helpers, surrogate keys, pivot, unpivot | First |
+| `dbt-expectations` | Must-have | Great Expectations-style data tests | First |
+| `codegen` | Development | Generate YAML, base models from sources | Dev only |
+| `dbt-date` | Situational | Date spine, fiscal calendars | When needed |
+| `audit-helper` | Situational | Compare model versions during refactoring | When needed |
+| `dbt-project-evaluator` | Recommended | Lint dbt project structure and naming | CI |
+| `elementary` | Recommended | Data observability, anomaly detection | Production |
+
+---
+
+### dbt-utils (Must-Have)
+
+**Install:**
+```yaml
+# packages.yml
+packages:
+  - package: dbt-labs/dbt_utils
+    version: [">=1.3.0", "<2.0.0"]
+```
+
+**Compatibility:** Snowflake, BigQuery, Postgres, Redshift, Databricks, Spark
+
+**Top features:**
+
+**1. Surrogate keys:**
+```sql
+-- Generate a deterministic surrogate key from multiple columns
+select
+    {{ dbt_utils.generate_surrogate_key(['order_id', 'payment_id']) }} as unique_key,
+    order_id,
+    payment_id,
+    amount_dollars
+from {{ ref('stg_stripe__payments') }}
+```
+
+**2. Pivot / Unpivot:**
+```sql
+-- Pivot payment methods into columns
+select
+    order_id,
+    {{ dbt_utils.pivot(
+        'payment_method',
+        dbt_utils.get_column_values(ref('stg_stripe__payments'), 'payment_method'),
+        agg='sum',
+        then_value='amount_dollars',
+        else_value='0'
+    ) }}
+from {{ ref('stg_stripe__payments') }}
+group by order_id
+```
+
+**3. Date spine:**
+```sql
+-- Generate a continuous date range (fill gaps in event data)
+{{ dbt_utils.date_spine(
+    datepart="day",
+    start_date="cast('2020-01-01' as date)",
+    end_date="current_date"
+) }}
+```
+
+---
+
+### dbt-expectations (Must-Have)
+
+**Install:**
+```yaml
+# packages.yml
+packages:
+  - package: calogica/dbt_expectations
+    version: [">=0.10.0", "<0.11.0"]
+```
+
+**Compatibility:** Snowflake, BigQuery, Postgres, Redshift
+
+**Top features:**
+
+**1. Column value ranges:**
+```yaml
+# _finance__models.yml
+models:
+  - name: fct_orders
+    columns:
+      - name: total_amount
+        data_tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+              max_value: 100000
+              row_condition: "order_status != 'cancelled'"
+```
+
+**2. Row count validation:**
+```yaml
+models:
+  - name: fct_orders
+    data_tests:
+      - dbt_expectations.expect_table_row_count_to_be_between:
+          min_value: 1000
+          warn_if: "<5000"
+          error_if: "<1000"
+```
+
+**3. Distribution tests:**
+```yaml
+columns:
+  - name: order_status
+    data_tests:
+      - dbt_expectations.expect_column_distinct_count_to_be_between:
+          min_value: 3
+          max_value: 6
+```
+
+---
+
+### codegen (Dev Only)
+
+**Install:**
+```yaml
+# packages.yml
+packages:
+  - package: dbt-labs/codegen
+    version: [">=0.12.0", "<0.13.0"]
+```
+
+**Compatibility:** Snowflake, BigQuery, Postgres, Redshift
+
+**Top features:**
+
+**1. Generate base model SQL:**
+```bash
+dbt run-operation codegen.generate_base_model --args '{"source_name": "stripe", "table_name": "payments"}'
+```
+
+**2. Generate model YAML:**
+```bash
+dbt run-operation codegen.generate_model_yaml --args '{"model_names": ["stg_stripe__payments"]}'
+```
+
+**3. Generate source YAML:**
+```bash
+dbt run-operation codegen.generate_source --args '{"schema_name": "stripe", "database_name": "raw"}'
+```
+
+---
+
+### dbt-date (Situational)
+
+**Install:**
+```yaml
+# packages.yml
+packages:
+  - package: calogica/dbt_date
+    version: [">=0.10.0", "<0.11.0"]
+```
+
+**Compatibility:** Snowflake, BigQuery, Postgres, Redshift
+
+**Top features:**
+
+**1. Date spine with fiscal support:**
+```sql
+select * from {{ dbt_date.get_date_dimension("2020-01-01", "2025-12-31") }}
+```
+
+**2. Date part helpers:**
+```sql
+select
+    order_date,
+    {{ dbt_date.day_name('order_date', short=true) }} as day_of_week,
+    {{ dbt_date.last_day('order_date', 'month') }} as month_end
+from {{ ref('fct_orders') }}
+```
+
+**3. Relative date ranges:**
+```sql
+where order_date >= {{ dbt_date.n_days_ago(30) }}
+```
+
+---
+
+### audit-helper (Situational)
+
+**Install:**
+```yaml
+# packages.yml
+packages:
+  - package: dbt-labs/audit_helper
+    version: [">=0.12.0", "<0.13.0"]
+```
+
+**Compatibility:** Snowflake, BigQuery, Postgres, Redshift
+
+**Top features:**
+
+**1. Compare model versions during refactoring:**
+```sql
+-- analyses/compare_orders_refactor.sql
+{% set old_relation = ref('fct_orders_v1') %}
+{% set new_relation = ref('fct_orders_v2') %}
+
+{{ audit_helper.compare_relations(
+    a_relation=old_relation,
+    b_relation=new_relation,
+    primary_key="order_id"
+) }}
+```
+
+**2. Compare column values:**
+```sql
+{{ audit_helper.compare_column_values(
+    a_relation=ref('fct_orders_v1'),
+    b_relation=ref('fct_orders_v2'),
+    primary_key="order_id",
+    column_to_compare="total_amount"
+) }}
+```
+
+**3. Compare row counts:**
+```sql
+{{ audit_helper.compare_row_counts(
+    a_relation=ref('fct_orders_v1'),
+    b_relation=ref('fct_orders_v2')
+) }}
+```
+
+---
+
+### dbt-project-evaluator (Recommended)
+
+**Install:**
+```yaml
+# packages.yml
+packages:
+  - package: dbt-labs/dbt_project_evaluator
+    version: [">=0.8.0", "<0.9.0"]
+```
+
+**Compatibility:** Snowflake, BigQuery, Postgres, Redshift, Databricks
+
+**Top features:**
+
+**1. Detect DAG violations (marts referencing staging directly):**
+```bash
+dbt build --select package:dbt_project_evaluator
+```
+
+**2. Naming convention enforcement:**
+- Flags models not following `stg_`, `int_`, `fct_`, `dim_` conventions
+- Detects missing primary key tests
+
+**3. CI integration:**
+```yaml
+# Run in CI to enforce project standards
+- name: Evaluate project structure
+  run: dbt build --select package:dbt_project_evaluator --target ci
+```
+
+---
+
+### elementary (Recommended)
+
+**Install:**
+```yaml
+# packages.yml
+packages:
+  - package: elementary-data/elementary
+    version: [">=0.16.0", "<0.17.0"]
+```
+
+**Compatibility:** Snowflake, BigQuery, Postgres, Redshift, Databricks
+
+**Top features:**
+
+**1. Anomaly detection tests:**
+```yaml
+models:
+  - name: fct_orders
+    data_tests:
+      - elementary.volume_anomalies:
+          timestamp_column: order_date
+          where: "order_status != 'cancelled'"
+      - elementary.freshness_anomalies:
+          timestamp_column: updated_at
+```
+
+**2. Column-level monitoring:**
+```yaml
+columns:
+  - name: total_amount
+    data_tests:
+      - elementary.column_anomalies:
+          timestamp_column: order_date
+          column_anomalies:
+            - zero_count
+            - null_count
+            - average
+```
+
+**3. Observability report:**
+```bash
+# Generate HTML report of data quality
+edr report
+```
+
+---
+
+## Package Management
+
+### packages.yml Syntax
+
+```yaml
+# packages.yml — Three installation methods
+
+packages:
+  # 1. Hub packages (recommended for public packages)
+  - package: dbt-labs/dbt_utils
+    version: [">=1.3.0", "<2.0.0"]
+
+  # 2. Git packages (for private or forked packages)
+  - git: "https://github.com/your-org/dbt-internal-utils.git"
+    revision: v0.3.0  # Tag, branch, or commit SHA
+
+  # 3. Local packages (for monorepo or co-located packages)
+  - local: ../dbt-shared-macros
+```
+
+### Version Pinning Strategies
+
+| Strategy | Syntax | Use Case |
+|----------|--------|----------|
+| Exact | `version: "1.3.0"` | Maximum stability, manual updates only |
+| Range (recommended) | `version: [">=1.3.0", "<2.0.0"]` | Accept patches and minors, block breaking changes |
+| Pessimistic | `version: [">=1.3.0", "<1.4.0"]` | Accept patches only |
+| Latest | (no version) | Never use in production |
+
+```yaml
+# DO: Pin with a range to accept patches
+packages:
+  - package: dbt-labs/dbt_utils
+    version: [">=1.3.0", "<2.0.0"]
+
+# DON'T: Leave version unpinned
+packages:
+  - package: dbt-labs/dbt_utils
+    # No version — will pull latest on every dbt deps run
+```
+
+### `dbt deps` — When and What
+
+| When to Run | What It Does |
+|-------------|-------------|
+| After cloning a repo | Installs all packages to `dbt_packages/` |
+| After editing `packages.yml` | Installs new or updated packages |
+| After pulling changes with `packages.yml` updates | Syncs local packages |
+| In CI pipeline (every run) | Ensures consistent package state |
+
+```bash
+# Install packages
+dbt deps
+
+# Packages installed to dbt_packages/ (add to .gitignore)
+echo "dbt_packages/" >> .gitignore
+```
+
+### Lock File Considerations
+
+dbt generates `package-lock.yml` to pin exact resolved versions.
+
+```yaml
+# Commit package-lock.yml for reproducible builds
+# dbt deps reads lock file when present, skipping resolution
+```
+
+| File | Commit? | Purpose |
+|------|---------|---------|
+| `packages.yml` | Yes | Declares version ranges |
+| `package-lock.yml` | Yes | Locks exact resolved versions |
+| `dbt_packages/` | No (.gitignore) | Installed package files |
+
+### Private Packages via Git
+
+**SSH authentication:**
+```yaml
+packages:
+  - git: "git@github.com:your-org/dbt-internal-utils.git"
+    revision: v0.3.0
+```
+
+**Token authentication (CI/CD):**
+```yaml
+packages:
+  - git: "https://{{ env_var('GIT_TOKEN') }}@github.com/your-org/dbt-internal-utils.git"
+    revision: v0.3.0
+```
+
+**Deploy key setup for CI:**
+```bash
+# In CI environment, configure SSH key
+mkdir -p ~/.ssh
+echo "$DEPLOY_KEY" > ~/.ssh/id_rsa
+chmod 600 ~/.ssh/id_rsa
+ssh-keyscan github.com >> ~/.ssh/known_hosts
+dbt deps
+```
+
+### Monorepo Local Packages
+
+```yaml
+# When multiple dbt projects share macros in the same repo
+packages:
+  - local: ../dbt-shared-macros
+
+# Directory structure:
+# monorepo/
+# ├── dbt-shared-macros/
+# │   ├── dbt_project.yml
+# │   └── macros/
+# │       └── utils/
+# ├── dbt-analytics/
+# │   ├── dbt_project.yml
+# │   ├── packages.yml       ← references ../dbt-shared-macros
+# │   └── models/
+# └── dbt-marketing/
+#     ├── dbt_project.yml
+#     ├── packages.yml       ← references ../dbt-shared-macros
+#     └── models/
+```
+
+---
+
+## Common Macro Patterns
+
+### `generate_schema_name` — Custom Schema Routing
+
+Override where models are built. The most commonly customized macro.
+
+```sql
+{# macros/schema/generate_schema_name.sql #}
+
+{% macro generate_schema_name(custom_schema_name, node) -%}
+    {%- set default_schema = target.schema -%}
+
+    {%- if target.name == 'prod' -%}
+        {# In prod: use the custom schema directly (e.g., "finance", "marketing") #}
+        {%- if custom_schema_name is not none -%}
+            {{ custom_schema_name | trim }}
+        {%- else -%}
+            {{ default_schema }}
+        {%- endif -%}
+
+    {%- else -%}
+        {# In dev/ci: prefix with developer schema (e.g., "dbt_dsong_finance") #}
+        {%- if custom_schema_name is not none -%}
+            {{ default_schema }}_{{ custom_schema_name | trim }}
+        {%- else -%}
+            {{ default_schema }}
+        {%- endif -%}
+
+    {%- endif -%}
+{%- endmacro %}
+```
+
+**Result:**
+
+| Environment | `custom_schema` | Built As |
+|-------------|----------------|----------|
+| dev (schema=dbt_dsong) | `finance` | `dbt_dsong_finance.fct_orders` |
+| dev (schema=dbt_dsong) | none | `dbt_dsong.my_model` |
+| prod (schema=analytics) | `finance` | `finance.fct_orders` |
+| prod (schema=analytics) | none | `analytics.my_model` |
+
+### `generate_alias_name` — Custom Table Alias
+
+Override the table name without renaming the file.
+
+```sql
+{# macros/schema/generate_alias_name.sql #}
+
+{% macro generate_alias_name(custom_alias_name, node) -%}
+    {%- if custom_alias_name -%}
+        {{ custom_alias_name | trim }}
+    {%- elif node.version -%}
+        {{ return(node.name ~ "_v" ~ node.version) }}
+    {%- else -%}
+        {{ node.name }}
+    {%- endif -%}
+{%- endmacro %}
+```
+
+### Grant Macros — Auto-Grant After Build
+
+```sql
+{# macros/grants/grant_select.sql #}
+
+{% macro grant_select(role) %}
+    {% if target.type == 'snowflake' %}
+        grant usage on schema {{ target.schema }} to role {{ role }};
+        grant select on all tables in schema {{ target.schema }} to role {{ role }};
+        grant select on all views in schema {{ target.schema }} to role {{ role }};
+    {% elif target.type == 'bigquery' %}
+        {# BigQuery uses IAM, not SQL grants — handle in Terraform/console #}
+        {{ log("BigQuery permissions managed via IAM, skipping SQL grant", info=true) }}
+    {% endif %}
+{% endmacro %}
+```
+
+**Usage as post-hook:**
+```yaml
+# dbt_project.yml
+models:
+  my_project:
+    marts:
+      +post-hook:
+        - "{{ grant_select('analytics_reader') }}"
+```
+
+### Logging Macros — Structured Debugging
+
+```sql
+{# macros/logging/log_model_timing.sql #}
+
+{% macro log_model_timing(step_name) %}
+    {{ log("TIMING | model=" ~ this.name ~ " | step=" ~ step_name ~ " | target=" ~ target.name, info=true) }}
+{% endmacro %}
+
+{# macros/logging/log_row_count.sql #}
+
+{% macro log_row_count(relation) %}
+    {% set row_count_query %}
+        select count(*) as row_count from {{ relation }}
+    {% endset %}
+    {% set results = run_query(row_count_query) %}
+    {% if execute %}
+        {% set row_count = results.columns[0][0] %}
+        {{ log("ROW_COUNT | relation=" ~ relation ~ " | count=" ~ row_count, info=true) }}
+    {% endif %}
+{% endmacro %}
+```
+
+### Deduplicate Macro — Snowflake QUALIFY vs BigQuery Workaround
+
+```sql
+{# macros/utils/deduplicate.sql #}
+
+{% macro deduplicate(relation, partition_by, order_by) %}
+    {% if target.type == 'snowflake' %}
+        select *
+        from {{ relation }}
+        qualify row_number() over (
+            partition by {{ partition_by }}
+            order by {{ order_by }} desc
+        ) = 1
+
+    {% elif target.type == 'bigquery' %}
+        select * except(rn)
+        from (
+            select
+                *,
+                row_number() over (
+                    partition by {{ partition_by }}
+                    order by {{ order_by }} desc
+                ) as rn
+            from {{ relation }}
+        )
+        where rn = 1
+    {% endif %}
+{% endmacro %}
+```
+
+**Usage:**
+```sql
+-- stg_shopify__orders.sql
+-- Deduplicate orders keeping the most recently updated record
+with source as (
+    select * from {{ source('shopify', 'orders') }}
+),
+
+deduped as (
+    {{ deduplicate(
+        relation='source',
+        partition_by='id',
+        order_by='updated_at'
+    ) }}
+)
+
+select
+    id as order_id,
+    customer_id,
+    status as order_status,
+    created_at as order_date,
+    updated_at
+from deduped
+```
+
+### Incremental Merge Predicate Macro
+
+```sql
+{# macros/utils/incremental_filter.sql #}
+
+{% macro incremental_filter(timestamp_column, lookback_hours=24) %}
+    {# Apply incremental filter with a safety lookback window #}
+    {% if is_incremental() %}
+        where {{ timestamp_column }} > (
+            select dateadd('hour', -{{ lookback_hours }}, max({{ timestamp_column }}))
+            from {{ this }}
+        )
+    {% endif %}
+{% endmacro %}
+```
+
+**Usage:**
+```sql
+select
+    event_id,
+    customer_id,
+    event_type,
+    event_timestamp
+from {{ ref('stg_segment__events') }}
+{{ incremental_filter('event_timestamp', lookback_hours=6) }}
+```
+
+---
+
+## Debugging Jinja
+
+### Core Debugging Workflow
+
+```
+1. dbt compile          →  Inspect generated SQL in target/compiled/
+2. {{ log() }}          →  Print variables and intermediate values
+3. dbt run-operation    →  Test macros in isolation
+4. dbt --debug run      →  Full verbose output with adapter logs
+```
+
+### `dbt compile` — Inspect Generated SQL
+
+```bash
+# Compile all models
+dbt compile
+
+# Compile a single model
+dbt compile --select fct_orders
+
+# Find compiled output
+cat target/compiled/my_project/models/marts/finance/fct_orders.sql
+```
+
+Compare the compiled SQL against expectations. Every Jinja tag is resolved — what remains is pure SQL.
+
+### `{{ log() }}` — Print Debug Messages
+
+```sql
+{# Print variable values during compilation #}
+{% set payment_methods = ['credit_card', 'bank_transfer', 'gift_card'] %}
+{{ log("payment_methods: " ~ payment_methods, info=true) }}
+
+{# Print target info #}
+{{ log("target.name=" ~ target.name ~ " target.type=" ~ target.type, info=true) }}
+
+{# Debug inside a loop #}
+{% for method in payment_methods %}
+    {{ log("Processing method: " ~ method ~ " (loop.index=" ~ loop.index ~ ")", info=true) }}
+{% endfor %}
+
+{# Debug macro arguments #}
+{% macro safe_divide(numerator, denominator) %}
+    {{ log("safe_divide called with: " ~ numerator ~ " / " ~ denominator, info=true) }}
+    ...
+{% endmacro %}
+```
+
+### `dbt run-operation` — Test Macros in Isolation
+
+```bash
+# Run a macro without building any models
+dbt run-operation safe_divide --args '{"numerator": "revenue", "denominator": "order_count"}'
+
+# Test macro with different targets
+dbt run-operation safe_divide --args '{"numerator": "10", "denominator": "0"}' --target dev
+
+# Run operational macros (grants, cleanup)
+dbt run-operation grant_select --args '{"role": "analytics_reader"}'
+```
+
+### Common Errors and Solutions
+
+| Error Message | Cause | Fix |
+|---------------|-------|-----|
+| `Compilation Error: 'xxx' is undefined` | Typo in variable, ref, or macro name | Check spelling; verify macro is in `macros/` directory |
+| `Compilation Error in ... (Jinja syntax)` | Mismatched `{% %}` tags or missing `{% endif %}` | Check every `if`/`for` has a matching `endif`/`endfor` |
+| `Parsing Error: expected token 'end of statement block', got '='` | Using `=` inside `{{ }}` (use `{% set %}` instead) | Move assignment to a `{% set %}` statement tag |
+| `Recursion limit reached` | Macro A calls macro B which calls macro A | Review call graph; break circular dependency |
+| `Runtime Error: maximum recursion depth` | `is_incremental()` logic causing self-reference loop | Ensure `{{ this }}` is only used inside `{% if is_incremental() %}` blocks |
+| `Database Error: relation does not exist` | `ref()` target model not yet built | Run with `dbt build` (respects DAG) or build upstream first |
+| `Encountered an error: 'run_query' is not defined` | Using `run_query` outside of execution context | Wrap with `{% if execute %}` guard |
+
+### The `execute` Guard
+
+`run_query()` and similar functions only work during execution, not during parsing.
+
+```sql
+{# DON'T: This fails during dbt parse/compile #}
+{% set results = run_query("select 1") %}
+{% set value = results.columns[0][0] %}
+
+{# DO: Guard with execute flag #}
+{% if execute %}
+    {% set results = run_query("select 1") %}
+    {% set value = results.columns[0][0] %}
+{% else %}
+    {% set value = none %}
+{% endif %}
+```
+
+### `dbt --debug run` — Verbose Output
+
+```bash
+# Full debug output including adapter SQL and timing
+dbt --debug run --select fct_orders
+
+# Combine with compile for maximum visibility
+dbt --debug compile --select fct_orders
+```
+
+### Debugging Checklist
+
+When Jinja produces unexpected SQL, follow this sequence:
+
+1. **Compile first:** `dbt compile --select <model>` and read `target/compiled/.../model.sql`
+2. **Add logging:** Insert `{{ log("variable=" ~ my_var, info=true) }}` around the problem area
+3. **Check context:** Verify `target.name`, `target.type`, `is_incremental()` return expected values
+4. **Isolate macros:** Test with `dbt run-operation` and explicit arguments
+5. **Check execute flag:** Ensure `run_query()` calls are inside `{% if execute %}` blocks
+6. **Review whitespace:** Use `{%- -%}` if extra blank lines appear in compiled SQL
+7. **Go verbose:** Run `dbt --debug run` for adapter-level SQL and response logging
+
+---
+
+**Back to:** [Main Skill File](../SKILL.md)

--- a/skills/dbt-skill/references/semantic-layer-governance.md
+++ b/skills/dbt-skill/references/semantic-layer-governance.md
@@ -1,0 +1,696 @@
+# Semantic Layer & Governance
+
+> **Part of:** [dbt-skill](../SKILL.md)
+> **Purpose:** MetricFlow semantic models, metric types, model contracts, versioning, access controls, dbt Mesh, and maturity assessment
+
+This document covers centralized metric definitions, governance features introduced in dbt 1.5+, and multi-project architecture. For core modeling patterns, see the [main skill file](../SKILL.md).
+
+---
+
+## Table of Contents
+
+1. [Semantic Layer Overview](#semantic-layer-overview)
+2. [MetricFlow Configuration](#metricflow-configuration)
+3. [Metric Types](#metric-types)
+4. [Model Contracts](#model-contracts-dbt-15)
+5. [Model Versions](#model-versions-dbt-16)
+6. [Access Controls](#access-controls-dbt-15)
+7. [dbt Mesh (Multi-Project)](#dbt-mesh-multi-project)
+8. [Maturity Assessment](#maturity-assessment)
+
+---
+
+## Semantic Layer Overview
+
+### What It Is
+
+The dbt Semantic Layer provides centralized metric definitions consumed by any BI tool (Looker, Tableau, Hex, Mode, Google Sheets). Define a metric once in dbt, query it from anywhere.
+
+### The Problem It Solves
+
+**"Different numbers in different dashboards."** Without a semantic layer:
+
+- Finance reports `$2.3M` revenue from a Looker dashboard
+- Marketing reports `$2.1M` revenue from a Tableau workbook
+- The CEO asks: "Which number is right?"
+
+The root cause: each tool has its own metric logic, filters, and joins. The semantic layer moves metric definitions upstream into dbt, creating a single source of truth.
+
+### Maturity Decision Matrix
+
+| Team Stage | Recommendation | Reason |
+|------------|---------------|--------|
+| Just starting | Skip Semantic Layer | Focus on modeling fundamentals first |
+| Running in prod | Evaluate adoption | Define key metrics centrally |
+| Multiple BI tools | Strongly adopt | Single source of metric truth |
+| Enterprise scale | Full platform | Governance, access control, versioning |
+
+### Prerequisites
+
+- **dbt Cloud:** The Semantic Layer API is a dbt Cloud feature (Team tier or higher)
+- **MetricFlow OSS:** Use for local development and testing (`pip install dbt-metricflow`)
+- **dbt Core 1.6+:** Required for `semantic_models` and `metrics` YAML blocks
+- **Supported warehouses:** Snowflake, BigQuery, Databricks, Redshift
+
+---
+
+## MetricFlow Configuration
+
+### Semantic Models
+
+Semantic models map dbt models to queryable entities, dimensions, and measures. Define them in YAML alongside your model configs.
+
+```yaml
+# models/marts/finance/_finance__semantic_models.yml
+semantic_models:
+  - name: orders
+    description: "Order fact table with payment details"
+    model: ref('fct_orders')
+    defaults:
+      agg_time_dimension: order_date  # default time dimension for metrics
+
+    # Entities define join keys
+    entities:
+      - name: order_id
+        type: primary
+      - name: customer_id
+        type: foreign
+
+    # Dimensions are groupable attributes
+    dimensions:
+      - name: order_date
+        type: time
+        type_params:
+          time_granularity: day
+      - name: order_status
+        type: categorical
+      - name: payment_method
+        type: categorical
+
+    # Measures are aggregatable values
+    measures:
+      - name: order_count
+        description: "Total number of orders"
+        agg: count
+        expr: order_id
+      - name: total_revenue
+        description: "Sum of order amounts in dollars"
+        agg: sum
+        expr: total_amount
+      - name: average_order_amount
+        description: "Average order value"
+        agg: average
+        expr: total_amount
+      - name: unique_customers
+        description: "Distinct customer count"
+        agg: count_distinct
+        expr: customer_id
+```
+
+### Entity Types
+
+| Type | Purpose | Example |
+|------|---------|---------|
+| `primary` | Unique identifier for the semantic model | `order_id` in orders |
+| `foreign` | Join key referencing another semantic model | `customer_id` in orders |
+| `unique` | Unique but not the primary identifier | `email` in customers |
+| `natural` | Business key that may change over time | `sku` in products |
+
+### Dimension Types
+
+| Type | Purpose | Example |
+|------|---------|---------|
+| `categorical` | Groupable string/enum values | `order_status`, `region` |
+| `time` | Date/timestamp for time-series analysis | `order_date`, `created_at` |
+
+### Measure Aggregation Types
+
+| Aggregation | SQL Equivalent | Use Case |
+|-------------|---------------|----------|
+| `sum` | `SUM(expr)` | Revenue, quantities |
+| `count` | `COUNT(expr)` | Row counts |
+| `count_distinct` | `COUNT(DISTINCT expr)` | Unique users, sessions |
+| `average` | `AVG(expr)` | Average order value |
+| `min` | `MIN(expr)` | First occurrence |
+| `max` | `MAX(expr)` | Most recent, largest |
+| `median` | `MEDIAN(expr)` | Median order size |
+| `percentile` | `PERCENTILE_CONT(expr)` | P95 latency, P50 revenue |
+
+---
+
+## Metric Types
+
+### Simple Metrics
+
+Direct reference to a single measure. Use for straightforward KPIs.
+
+```yaml
+metrics:
+  - name: total_revenue
+    description: "Sum of all order amounts"
+    type: simple
+    label: "Total Revenue"
+    type_params:
+      measure: total_revenue  # references measure in semantic model
+```
+
+### Derived Metrics
+
+Math on other metrics. Use for ratios, percentages, and calculated KPIs.
+
+```yaml
+metrics:
+  - name: average_order_value
+    description: "Revenue per order"
+    type: derived
+    label: "Average Order Value (AOV)"
+    type_params:
+      expr: total_revenue / order_count  # references other metrics
+      metrics:
+        - name: total_revenue
+        - name: order_count
+
+```
+
+### Cumulative Metrics
+
+Running totals over time windows. Use for MRR, cumulative revenue, running user counts.
+
+```yaml
+metrics:
+  - name: cumulative_revenue
+    description: "Running total of revenue over all time"
+    type: cumulative
+    label: "Cumulative Revenue"
+    type_params:
+      measure: total_revenue
+      # No window = all-time running total
+
+  - name: trailing_28d_revenue
+    description: "Rolling 28-day revenue window"
+    type: cumulative
+    label: "28-Day Revenue"
+    type_params:
+      measure: total_revenue
+      window: 28 days  # rolling window
+      # Commonly used: 7 days, 28 days, 90 days, 1 year
+```
+
+### Conversion Metrics
+
+Funnel metrics that track progression between events. Use for signup funnels, purchase funnels, onboarding flows.
+
+```yaml
+metrics:
+  - name: visit_to_purchase_rate
+    description: "Percentage of site visits that result in a purchase"
+    type: conversion
+    label: "Visit-to-Purchase Rate"
+    type_params:
+      conversion_type_params:
+        entity: customer_id                # entity to track through funnel
+        base_measure: site_visits          # top of funnel
+        conversion_measure: order_count    # bottom of funnel
+        window: 7 days                     # conversion window
+```
+
+### DO / DON'T: Metric Definitions
+
+```yaml
+# DO: Define metrics in dbt, query from BI tools
+metrics:
+  - name: total_revenue
+    type: simple
+    type_params:
+      measure: total_revenue
+
+# DON'T: Redefine the same metric in each BI tool
+# Looker: SUM(total_amount) WHERE status = 'completed'
+# Tableau: SUM(total_amount) WHERE status IN ('completed', 'shipped')
+# These will produce different numbers
+```
+
+---
+
+## Model Contracts (dbt 1.5+)
+
+### What They Are
+
+Model contracts enforce column names and data types at build time. If a downstream consumer expects `order_id` to be a `string`, the contract guarantees it. A build fails if the SQL output does not match the contract.
+
+### Configuration
+
+```yaml
+# models/marts/finance/_finance__models.yml
+models:
+  - name: fct_orders
+    description: "One record per order with payment details"
+    config:
+      contract:
+        enforced: true  # build fails if schema doesn't match
+    columns:
+      - name: order_id
+        data_type: string
+        data_tests: [unique, not_null]
+      - name: customer_id
+        data_type: string
+        data_tests:
+          - not_null
+          - relationships:
+              to: ref('dim_customers')
+              field: customer_id
+      - name: order_date
+        data_type: date
+        data_tests: [not_null]
+      - name: order_status
+        data_type: string
+        data_tests:
+          - accepted_values:
+              values: ['completed', 'pending', 'cancelled', 'refunded']
+      - name: total_amount
+        data_type: float
+        data_tests: [not_null]
+```
+
+### Snowflake vs BigQuery Type Mapping
+
+| Logical Type | Snowflake | BigQuery |
+|-------------|-----------|----------|
+| string | VARCHAR | STRING |
+| integer | NUMBER(38,0) | INT64 |
+| float | FLOAT | FLOAT64 |
+| boolean | BOOLEAN | BOOL |
+| timestamp | TIMESTAMP_NTZ | TIMESTAMP |
+| date | DATE | DATE |
+
+Use the **logical type** (left column) in your contract YAML. dbt translates to the warehouse-specific type automatically.
+
+### When to Enforce Contracts
+
+| Layer | Enforce? | Reason |
+|-------|----------|--------|
+| Staging | No | Too rigid for cleaning layer; schemas change with source |
+| Intermediate | No | Internal helper models; not consumed externally |
+| Marts | **Yes** | Stable interface for BI tools and downstream teams |
+| Any model consumed by external teams | **Yes** | Prevents breaking changes |
+| Any model in the Semantic Layer | **Yes** | MetricFlow requires stable schemas |
+
+### DO / DON'T: Contracts
+
+```yaml
+# DO: Enforce contracts on marts consumed by BI tools
+models:
+  - name: fct_orders
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: order_id
+        data_type: string
+
+# DON'T: Enforce contracts on staging models
+models:
+  - name: stg_stripe__payments
+    config:
+      contract:
+        enforced: true  # Too rigid -- source schema changes will break builds
+```
+
+---
+
+## Model Versions (dbt 1.6+)
+
+### What They Are
+
+Model versions allow multiple versions of the same model to run simultaneously. Use them when you need to change a model's schema without breaking downstream consumers.
+
+### Version Configuration
+
+```yaml
+# models/marts/finance/_finance__models.yml
+models:
+  - name: fct_orders
+    description: "One record per order"
+    latest_version: 2
+    config:
+      contract:
+        enforced: true
+    columns:  # shared across versions
+      - name: order_id
+        data_type: string
+        data_tests: [unique, not_null]
+      - name: customer_id
+        data_type: string
+      - name: order_date
+        data_type: date
+      - name: order_status
+        data_type: string
+      - name: total_amount
+        data_type: float
+    versions:
+      - v: 1
+        # v1 uses the default column set above
+        defined_in: fct_orders_v1       # points to fct_orders_v1.sql
+        deprecation_date: 2025-06-01    # warn consumers to migrate
+      - v: 2
+        defined_in: fct_orders_v2       # points to fct_orders_v2.sql
+        columns:
+          # v2 adds a new column not in v1
+          - include: all
+          - name: discount_amount
+            data_type: float
+            description: "Discount applied to the order"
+```
+
+### SQL Files for Each Version
+
+```sql
+-- models/marts/finance/fct_orders_v1.sql (original -- no discount column)
+with orders as (
+    select * from {{ ref('stg_shopify__orders') }}
+),
+payments as (
+    select * from {{ ref('int_payments_pivoted') }}
+),
+final as (
+    select
+        orders.order_id, orders.customer_id, orders.order_date,
+        orders.order_status, payments.total_amount
+    from orders
+    left join payments on orders.order_id = payments.order_id
+)
+select * from final
+```
+
+```sql
+-- models/marts/finance/fct_orders_v2.sql (adds discount_amount)
+with orders as (
+    select * from {{ ref('stg_shopify__orders') }}
+),
+payments as (
+    select * from {{ ref('int_payments_pivoted') }}
+),
+discounts as (
+    select * from {{ ref('int_discounts_applied') }}
+),
+final as (
+    select
+        orders.order_id, orders.customer_id, orders.order_date,
+        orders.order_status, payments.total_amount,
+        coalesce(discounts.discount_amount, 0) as discount_amount
+    from orders
+    left join payments on orders.order_id = payments.order_id
+    left join discounts on orders.order_id = discounts.order_id
+)
+select * from final
+```
+
+### Referencing Versioned Models
+
+```sql
+-- Default: references the latest_version (v2)
+select * from {{ ref('fct_orders') }}
+
+-- Explicit version: pin to a specific version
+select * from {{ ref('fct_orders', v=1) }}  -- still using v1
+select * from {{ ref('fct_orders', v=2) }}  -- explicitly v2
+```
+
+### Migration Strategy
+
+1. **Create v2 alongside v1** -- both run in production simultaneously
+2. **Migrate consumers one at a time** -- update `ref()` calls or let `latest_version` handle it
+3. **Set deprecation date on v1** -- dbt warns when building deprecated versions
+4. **Remove v1 after all consumers migrated** -- delete the version entry and SQL file
+
+### DO / DON'T: Versioning
+
+```yaml
+# DO: Use versions for breaking schema changes on public models
+models:
+  - name: fct_orders
+    latest_version: 2
+    versions:
+      - v: 1
+        deprecation_date: 2025-06-01
+      - v: 2
+
+# DON'T: Version every model -- only version models with external consumers
+# DON'T: Use versions for additive changes (just add the column to the existing model)
+```
+
+---
+
+## Access Controls (dbt 1.5+)
+
+### Access Levels
+
+| Level | Who Can `ref()` | Use Case |
+|-------|-----------------|----------|
+| `private` | Same group only | Internal helper models |
+| `protected` | Same project (default) | Standard within-project models |
+| `public` | Any project | Stable interfaces for cross-project use |
+
+### Group Definitions
+
+Define groups in `dbt_project.yml` to represent teams or domains:
+
+```yaml
+# dbt_project.yml
+groups:
+  - name: finance
+    owner:
+      name: Finance Analytics
+      email: finance-analytics@company.com
+  - name: marketing
+    owner:
+      name: Marketing Analytics
+      email: marketing-analytics@company.com
+  - name: product
+    owner:
+      name: Product Analytics
+      email: product-analytics@company.com
+```
+
+### Assigning Models to Groups
+
+In YAML (`_finance__models.yml`):
+
+```yaml
+models:
+  - name: fct_orders
+    config: { group: finance }
+    access: public           # any project can ref() this model
+  - name: int_payments_pivoted
+    config: { group: finance }
+    access: private          # only finance group can ref() this model
+  - name: dim_customers
+    config: { group: finance }
+    access: protected        # only this project can ref() (default)
+```
+
+Or in the model SQL file:
+
+```sql
+{{ config(materialized='table', group='finance', access='public') }}
+```
+
+### Cross-Group Restrictions
+
+When a model in the `marketing` group tries to `ref()` a `private` model in the `finance` group, dbt raises an error:
+
+```
+Access to model 'int_payments_pivoted' is restricted.
+Model is private to group 'finance'.
+```
+
+**Resolution options:**
+
+1. Change the upstream model to `protected` or `public`
+2. Create a `public` interface model in the finance group that exposes only the needed columns
+3. Move the consuming model into the same group
+
+### DO / DON'T: Access Controls
+
+```yaml
+# DO: Mark marts consumed by other teams as public
+models:
+  - name: fct_orders
+    access: public
+    config:
+      group: finance
+      contract:
+        enforced: true  # public models should always have contracts
+
+# DON'T: Make intermediate models public
+models:
+  - name: int_payments_pivoted
+    access: public  # Too much exposure -- internal logic may change
+```
+
+---
+
+## dbt Mesh (Multi-Project)
+
+### What It Is
+
+dbt Mesh enables cross-project `ref()` for large organizations. Each team owns a dbt project; projects reference each other's `public` models through a dependency graph.
+
+### When to Split Into Multiple Projects
+
+| Signal | Action |
+|--------|--------|
+| 50+ models in a single project | Consider splitting by domain |
+| Multiple teams owning different domains | Split by domain ownership |
+| Different deployment cadences | Split by cadence (hourly vs daily) |
+| Shared utility models (date spine, currency rates) | Extract to a shared project |
+| CI builds taking 30+ minutes | Split to enable independent builds |
+
+### Producer / Consumer Pattern
+
+```
+shared_project (producer)       finance_project (consumer)       marketing_project (consumer)
+  dim_date (public) ──────────▶ ref('shared', 'dim_date')
+  dim_currency (public) ──────▶ fct_orders ──────────────────▶ ref('finance', 'fct_orders')
+  stg_* (private)               dim_customers                   fct_campaigns
+```
+
+- **Producer** publishes `public` models with enforced contracts
+- **Consumer** references them via cross-project `ref()`
+
+### Dependencies Configuration
+
+```yaml
+# finance_project/dependencies.yml
+projects:
+  - name: shared_project
+    # dbt Cloud resolves this automatically
+    # For dbt Core, specify the path or package
+
+  - name: marketing_project
+    # Only needed if finance also consumes from marketing
+```
+
+### Complete Example Setup
+
+**Shared project -- publishes utility models:**
+
+```yaml
+# shared_project/models/marts/_shared__models.yml
+models:
+  - name: dim_date
+    access: public
+    config:
+      group: platform
+      contract:
+        enforced: true
+    columns:
+      - name: date_key
+        data_type: date
+        data_tests: [unique, not_null]
+      - name: day_of_week
+        data_type: string
+      - name: fiscal_quarter
+        data_type: string
+      - name: is_holiday
+        data_type: boolean
+```
+
+**Finance project -- consumes shared, publishes to marketing:**
+
+```sql
+-- finance_project/models/marts/fct_daily_revenue.sql
+{{ config(materialized='table', group='finance', access='public', contract={'enforced': true}) }}
+
+with orders as (
+    select * from {{ ref('fct_orders') }}
+),
+dates as (
+    select * from {{ ref('shared_project', 'dim_date') }}  -- cross-project ref
+),
+final as (
+    select
+        dates.date_key, dates.fiscal_quarter, dates.is_holiday,
+        count(orders.order_id) as order_count,
+        sum(orders.total_amount) as daily_revenue
+    from orders
+    inner join dates on orders.order_date = dates.date_key
+    group by 1, 2, 3
+)
+select * from final
+```
+
+### dbt Mesh Checklist
+
+Before enabling cross-project refs:
+
+- [ ] All shared models have `access: public`
+- [ ] All public models have `contract: { enforced: true }`
+- [ ] Groups and owners are defined for every model
+- [ ] `dependencies.yml` is configured in consumer projects
+- [ ] Deployment order is documented (producers build before consumers)
+- [ ] Cross-project tests are in place (relationships, freshness)
+
+---
+
+## Maturity Assessment
+
+Use this table to identify your current stage and plan next steps.
+
+### Capability Matrix
+
+| Capability | Just Starting | Running in Prod | Multiple Teams | Enterprise |
+|------------|--------------|----------------|----------------|------------|
+| **Testing** | Basic YAML tests | Custom generics, unit tests | dbt-expectations, contracts | Full coverage + anomaly detection |
+| **CI/CD** | Manual runs | GitHub Actions, Slim CI | dbt Cloud, blue/green | Multi-project orchestration |
+| **Governance** | Naming conventions | Access controls, groups | Model versions, contracts | dbt Mesh, Semantic Layer |
+| **Observability** | Source freshness | Elementary, Slack alerts | SLAs, incident runbooks | Full platform, PagerDuty |
+| **Documentation** | Basic descriptions | Column descriptions, exposures | Data dictionary, lineage | Governed catalog |
+
+### Actionable Next Steps by Stage
+
+**Just Starting -- advance to Running in Prod:**
+
+1. Add `unique` and `not_null` tests to every primary key
+2. Set up `dbt build` in a CI pipeline (GitHub Actions or similar)
+3. Configure source freshness checks with `loaded_at_field`
+4. Write column-level descriptions for all marts models
+
+**Running in Prod -- advance to Multiple Teams:**
+
+1. Define groups and assign model ownership in `dbt_project.yml`
+2. Set `access: public` on marts, `access: private` on intermediates
+3. Enforce contracts on all models consumed by BI tools
+4. Install `dbt-expectations` for advanced data quality tests
+5. Create Slack alerts for test failures and source freshness warnings
+
+**Multiple Teams -- advance to Enterprise:**
+
+1. Evaluate dbt Mesh: identify producer and consumer projects
+2. Implement model versions for any public model with breaking changes
+3. Deploy the Semantic Layer: define semantic models and metrics for top 10 KPIs
+4. Set SLAs for data freshness (e.g., "marts refresh within 2 hours of source load")
+5. Build incident runbooks for common data quality failures
+
+**Enterprise -- maintain and optimize:**
+
+1. Integrate Semantic Layer with all BI tools (single metric definitions)
+2. Implement automated anomaly detection (Elementary or Monte Carlo)
+3. Set up PagerDuty / on-call rotation for critical pipeline failures
+4. Version all public models; enforce deprecation timelines
+5. Publish a governed data catalog with lineage and ownership metadata
+
+### Governance Quick Reference
+
+| Feature | dbt Version | Purpose | Apply To |
+|---------|------------|---------|----------|
+| Access controls | 1.5+ | Restrict who can `ref()` a model | All models |
+| Model contracts | 1.5+ | Enforce schema at build time | Marts, public models |
+| Groups | 1.5+ | Assign team ownership | All models |
+| Model versions | 1.6+ | Run multiple versions simultaneously | Public models with breaking changes |
+| Semantic Layer | 1.6+ / Cloud | Centralized metric definitions | Key business metrics |
+| dbt Mesh | 1.6+ / Cloud | Cross-project `ref()` | Multi-team organizations |
+
+---
+
+**Back to:** [Main Skill File](../SKILL.md)

--- a/skills/dbt-skill/references/testing-quality.md
+++ b/skills/dbt-skill/references/testing-quality.md
@@ -1,0 +1,888 @@
+# Testing & Quality Strategy
+
+> **Part of:** [dbt-skill](../SKILL.md)
+> **Purpose:** Deep dive into schema tests, generic tests, singular tests, unit tests, dbt-expectations, dbt-utils testing helpers, and layer-specific testing strategy
+
+This document provides comprehensive testing guidance for dbt projects. For the testing overview and quick examples, see the [main skill file](../SKILL.md#basic-testing-overview).
+
+---
+
+## Table of Contents
+
+1. [Schema Tests (YAML-based)](#schema-tests-yaml-based)
+2. [Custom Singular Tests](#custom-singular-tests)
+3. [Custom Generic Tests](#custom-generic-tests)
+4. [Unit Tests (dbt 1.8+)](#unit-tests-dbt-18)
+5. [dbt-expectations Package](#dbt-expectations-package)
+6. [dbt-utils Testing Helpers](#dbt-utils-testing-helpers)
+7. [Test Configuration](#test-configuration)
+8. [Testing Strategy by Layer](#testing-strategy-by-layer)
+9. [Anti-patterns](#anti-patterns)
+
+---
+
+## Schema Tests (YAML-based)
+
+Schema tests are the foundation of dbt testing. Define them in YAML alongside model documentation. dbt ships four built-in tests.
+
+### Built-in Tests
+
+```yaml
+# _finance__models.yml
+version: 2
+
+models:
+  - name: fct_orders
+    columns:
+      - name: order_id
+        data_tests:
+          - unique                          # Every value must be distinct
+          - not_null                        # No NULL values allowed
+      - name: order_status
+        data_tests:
+          - accepted_values:               # Value must be in the set
+              values: ['completed', 'pending', 'cancelled', 'refunded']
+              # Snowflake/BigQuery: case-sensitive — apply lower() in staging
+      - name: customer_id
+        data_tests:
+          - not_null:
+              where: "order_status != 'draft'"   # Conditional scope
+          - relationships:                  # Referential integrity
+              to: ref('dim_customers')
+              field: customer_id
+              # Runs a LEFT JOIN — watch for cost on large tables
+              where: "customer_id is not null"    # Skip intentional orphans
+```
+
+### Configuration Options
+
+Every schema test accepts optional configuration:
+
+```yaml
+      - name: order_id
+        data_tests:
+          - unique:
+              severity: warn            # warn (non-blocking) or error (default, blocks pipeline)
+              where: "order_date >= '2024-01-01'"  # Filter test scope
+              config:
+                store_failures: true    # Persist failing rows to a table for debugging
+                limit: 100             # Cap number of failure rows returned
+                tags: ['primary_key']  # Tag for selective test execution
+```
+
+### Compound Uniqueness with dbt-utils
+
+When a primary key is a combination of columns:
+
+```yaml
+models:
+  - name: fct_order_items
+    description: "One record per order line item"
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - order_id
+            - line_item_id
+          # Generates: SELECT ... GROUP BY order_id, line_item_id HAVING count(*) > 1
+```
+
+---
+
+## Custom Singular Tests
+
+Singular tests are standalone SQL files in the `tests/` directory. The query must return **zero rows** to pass. Any row returned is a test failure.
+
+### File Naming
+
+```
+tests/
+├── assert_total_payment_amount_is_positive.sql
+├── assert_order_dates_not_in_future.sql
+├── assert_payment_revenue_matches_orders.sql
+└── generic/                  # Generic tests go in a subdirectory
+```
+
+Use the prefix `assert_` for clarity.
+
+### Example: Revenue Reconciliation
+
+```sql
+-- tests/assert_payment_revenue_matches_orders.sql
+-- Returns rows where revenue totals diverge by more than $1.00
+with order_totals as (
+    select sum(total_amount) as total_order_revenue
+    from {{ ref('fct_orders') }}
+    where order_status = 'completed'
+),
+payment_totals as (
+    select sum(amount_dollars) as total_payment_revenue
+    from {{ ref('stg_stripe__payments') }}
+    where payment_status = 'completed'
+)
+select
+    order_totals.total_order_revenue,
+    payment_totals.total_payment_revenue,
+    abs(order_totals.total_order_revenue - payment_totals.total_payment_revenue) as difference
+from order_totals
+cross join payment_totals
+where abs(order_totals.total_order_revenue - payment_totals.total_payment_revenue) > 1.00
+```
+
+### Example: Date Range Validation
+
+```sql
+-- tests/assert_order_dates_not_in_future.sql
+select order_id, order_date
+from {{ ref('fct_orders') }}
+where order_date > current_date
+   or order_date < '2020-01-01'  -- Business founded in 2020
+```
+
+### Example: Cross-table Consistency
+
+```sql
+-- tests/assert_completed_orders_have_payments.sql
+-- Returns completed orders with no corresponding payment record
+select o.order_id, o.order_status, o.order_date
+from {{ ref('fct_orders') }} o
+left join {{ ref('stg_stripe__payments') }} p
+    on o.order_id = p.order_id
+where o.order_status = 'completed'
+  and p.payment_id is null
+```
+
+### Singular vs Generic: Decision Table
+
+| Criterion | Use Singular | Use Generic |
+|-----------|-------------|-------------|
+| Business rule specific to one model | Yes | No |
+| Cross-table reconciliation | Yes | No |
+| Reusable across multiple models | No | Yes |
+| Needs parameters (column, threshold) | No | Yes |
+| Complex multi-step validation | Yes | No |
+| Standard data quality check | No | Yes |
+
+---
+
+## Custom Generic Tests
+
+Generic tests are reusable test macros. Define them in `tests/generic/` and apply them in YAML like built-in tests.
+
+### Example: `is_positive`
+
+```sql
+-- tests/generic/is_positive.sql
+{% test is_positive(model, column_name) %}
+
+select {{ column_name }} as failing_value
+from {{ model }}
+where {{ column_name }} < 0
+
+{% endtest %}
+```
+
+```yaml
+models:
+  - name: fct_orders
+    columns:
+      - name: total_amount
+        data_tests:
+          - is_positive           # Custom generic test
+```
+
+### Example: `row_count_matches`
+
+```sql
+-- tests/generic/row_count_matches.sql
+{% test row_count_matches(model, compare_model) %}
+
+with source_count as (
+    select count(*) as row_count from {{ model }}
+),
+compare_count as (
+    select count(*) as row_count from {{ ref(compare_model) }}
+)
+select
+    source_count.row_count as source_rows,
+    compare_count.row_count as compare_rows
+from source_count
+cross join compare_count
+where source_count.row_count != compare_count.row_count
+
+{% endtest %}
+```
+
+```yaml
+models:
+  - name: fct_orders
+    data_tests:
+      - row_count_matches:
+          compare_model: stg_shopify__orders
+```
+
+### Parameterized with Defaults
+
+```sql
+-- tests/generic/value_is_between.sql
+{% test value_is_between(model, column_name, min_value=0, max_value=none) %}
+
+select {{ column_name }} as failing_value
+from {{ model }}
+where {{ column_name }} < {{ min_value }}
+{% if max_value is not none %}
+   or {{ column_name }} > {{ max_value }}
+{% endif %}
+
+{% endtest %}
+```
+
+```yaml
+      - name: discount_percent
+        data_tests:
+          - value_is_between:
+              min_value: 0
+              max_value: 100
+```
+
+---
+
+## Unit Tests (dbt 1.8+)
+
+Unit tests validate transformation logic by mocking inputs and asserting expected outputs. They run against static data without querying the warehouse.
+
+### YAML Syntax
+
+```yaml
+unit_tests:
+  - name: test_fct_orders_total_calculation
+    description: "Verify order totals sum correctly from payment pivots"
+    model: fct_orders
+    given:
+      - input: ref('stg_shopify__orders')
+        rows:
+          - { order_id: 1, customer_id: 100, order_date: '2024-06-01', order_status: 'completed' }
+          - { order_id: 2, customer_id: 101, order_date: '2024-06-02', order_status: 'completed' }
+      - input: ref('int_payments_pivoted')
+        rows:
+          - { order_id: 1, credit_card_amount: 50.00, bank_transfer_amount: 25.00, total_amount: 75.00 }
+          - { order_id: 2, credit_card_amount: 100.00, bank_transfer_amount: 0.00, total_amount: 100.00 }
+    expect:
+      rows:
+        - { order_id: 1, customer_id: 100, order_status: 'completed', total_amount: 75.00 }
+        - { order_id: 2, customer_id: 101, order_status: 'completed', total_amount: 100.00 }
+```
+
+### Complete Example: Testing Business Logic
+
+Test a model that applies tiered discount logic:
+
+```sql
+-- models/intermediate/int_orders_with_discount.sql
+with orders as (
+    select * from {{ ref('stg_shopify__orders') }}
+),
+final as (
+    select
+        order_id, customer_id, subtotal,
+        case
+            when subtotal >= 500 then subtotal * 0.10   -- 10% discount over $500
+            when subtotal >= 200 then subtotal * 0.05   -- 5% discount over $200
+            else 0
+        end as discount_amount,
+        subtotal - case
+            when subtotal >= 500 then subtotal * 0.10
+            when subtotal >= 200 then subtotal * 0.05
+            else 0
+        end as total_after_discount
+    from orders
+)
+select * from final
+```
+
+```yaml
+unit_tests:
+  - name: test_tiered_discount_logic
+    description: "Verify discount tiers: 10% over $500, 5% over $200, 0% under $200"
+    model: int_orders_with_discount
+    given:
+      - input: ref('stg_shopify__orders')
+        rows:
+          - { order_id: 1, customer_id: 100, subtotal: 600.00 }  # 10% tier
+          - { order_id: 2, customer_id: 101, subtotal: 300.00 }  # 5% tier
+          - { order_id: 3, customer_id: 102, subtotal: 100.00 }  # No discount
+    expect:
+      rows:
+        - { order_id: 1, customer_id: 100, subtotal: 600.00, discount_amount: 60.00, total_after_discount: 540.00 }
+        - { order_id: 2, customer_id: 101, subtotal: 300.00, discount_amount: 15.00, total_after_discount: 285.00 }
+        - { order_id: 3, customer_id: 102, subtotal: 100.00, discount_amount: 0, total_after_discount: 100.00 }
+```
+
+### Overriding Macros
+
+```yaml
+unit_tests:
+  - name: test_with_mocked_macro
+    model: fct_orders
+    given:
+      - input: ref('stg_shopify__orders')
+        rows:
+          - { order_id: 1, customer_id: 100, order_date: '2024-06-01', order_status: 'completed' }
+    overrides:
+      macros:
+        is_incremental: false     # Force full-refresh path in unit test
+    expect:
+      rows:
+        - { order_id: 1, customer_id: 100, order_status: 'completed' }
+```
+
+### Limitations and Compatibility
+
+| Limitation | Details |
+|-----------|---------|
+| No warehouse functions | Cannot test `current_timestamp()`, warehouse-specific UDFs |
+| Static data only | Mocked rows are hardcoded — no dynamic test data |
+| No incremental testing | Cannot test merge behavior or deduplication |
+| Column matching | `expect` must include all columns the model selects |
+
+| Feature | Snowflake | BigQuery |
+|---------|-----------|----------|
+| Unit test support | dbt 1.8+ | dbt 1.8+ |
+| Date format in rows | `'2024-06-01'` (ISO) | `'2024-06-01'` (ISO) |
+| Numeric precision | FLOAT/NUMBER | FLOAT64/NUMERIC |
+| Execution method | Temporary tables | Temporary tables |
+
+### When to Use Unit Tests
+
+| Scenario | Use Unit Tests? |
+|----------|----------------|
+| Complex CASE/WHEN business logic | Yes |
+| Multi-step calculations (discounts, taxes) | Yes |
+| Jinja conditional logic paths | Yes |
+| Simple column renames in staging | No -- overkill |
+| Incremental merge behavior | No -- not supported |
+| Testing warehouse functions | No -- not supported |
+
+---
+
+## dbt-expectations Package
+
+[dbt-expectations](https://github.com/calogica/dbt-expectations) ports Great Expectations tests to dbt.
+
+### Installation
+
+```yaml
+# packages.yml
+packages:
+  - package: calogica/dbt_expectations
+    version: [">=0.10.0", "<0.11.0"]  # Pin to minor version range
+```
+
+### Top 10 Most Useful Expectations
+
+#### 1. `expect_column_values_to_not_be_null`
+
+Like `not_null` but supports `row_condition` filtering.
+
+```yaml
+      - name: customer_id
+        data_tests:
+          - dbt_expectations.expect_column_values_to_not_be_null:
+              row_condition: "order_status = 'completed'"
+```
+
+#### 2. `expect_column_values_to_be_between`
+
+Assert numeric values fall within a range.
+
+```yaml
+      - name: total_amount
+        data_tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+              max_value: 100000      # Flag suspiciously large orders
+```
+
+#### 3. `expect_column_values_to_be_in_set`
+
+Like `accepted_values` with more configuration.
+
+```yaml
+      - name: payment_method
+        data_tests:
+          - dbt_expectations.expect_column_values_to_be_in_set:
+              value_set: ['credit_card', 'bank_transfer', 'gift_card', 'store_credit']
+              row_condition: "payment_status != 'failed'"
+```
+
+#### 4. `expect_column_distinct_count_to_equal`
+
+Assert the exact number of distinct values.
+
+```yaml
+      - name: order_status
+        data_tests:
+          - dbt_expectations.expect_column_distinct_count_to_equal:
+              value: 4              # Catches silent schema drift
+```
+
+#### 5. `expect_column_values_to_match_regex`
+
+Validate string format with regular expressions.
+
+```yaml
+      - name: email
+        data_tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: "^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$"
+              # Snowflake: REGEXP_LIKE | BigQuery: REGEXP_CONTAINS
+```
+
+#### 6. `expect_table_row_count_to_be_between`
+
+Assert table size stays within bounds. Catches catastrophic data drops.
+
+```yaml
+models:
+  - name: fct_orders
+    data_tests:
+      - dbt_expectations.expect_table_row_count_to_be_between:
+          min_value: 1000        # Fewer = data pipeline issue
+          max_value: 10000000    # More = duplication bug
+```
+
+#### 7. `expect_column_values_to_be_unique`
+
+Like `unique` but supports `row_condition`.
+
+```yaml
+      - name: email
+        data_tests:
+          - dbt_expectations.expect_column_values_to_be_unique:
+              row_condition: "is_active = true"
+```
+
+#### 8. `expect_column_pair_values_A_to_be_greater_than_B`
+
+Assert ordering between two columns.
+
+```yaml
+    data_tests:
+      - dbt_expectations.expect_column_pair_values_A_to_be_greater_than_B:
+          column_A: total_amount
+          column_B: discount_amount
+          or_equal: true          # total >= discount
+```
+
+#### 9. `expect_column_mean_to_be_between`
+
+Statistical guardrail for anomalous shifts.
+
+```yaml
+      - name: total_amount
+        data_tests:
+          - dbt_expectations.expect_column_mean_to_be_between:
+              min_value: 20        # Avg below $20 = problem
+              max_value: 500       # Avg above $500 = duplication
+              severity: warn
+```
+
+#### 10. `expect_table_row_count_to_equal_other_table`
+
+Assert two tables have matching row counts.
+
+```yaml
+    data_tests:
+      - dbt_expectations.expect_table_row_count_to_equal_other_table:
+          compare_model: ref('fct_orders_v2')
+          # Migration validation: old model count must match new
+```
+
+---
+
+## dbt-utils Testing Helpers
+
+```yaml
+# packages.yml
+packages:
+  - package: dbt-labs/dbt_utils
+    version: [">=1.3.0", "<2.0.0"]
+```
+
+### `equal_rowcount`
+
+```yaml
+models:
+  - name: fct_orders
+    data_tests:
+      - dbt_utils.equal_rowcount:
+          compare_model: ref('stg_shopify__orders')
+          # Staging and fact should have same row count (1:1 grain)
+```
+
+### `fewer_rows_than`
+
+```yaml
+models:
+  - name: dim_customers
+    data_tests:
+      - dbt_utils.fewer_rows_than:
+          compare_model: ref('fct_orders')
+          # Customers should always be fewer than orders
+```
+
+### `not_accepted_values`
+
+```yaml
+      - name: order_status
+        data_tests:
+          - dbt_utils.not_accepted_values:
+              values: ['test', 'debug', 'staging']
+              # Ensure test data never leaks into production
+```
+
+### `expression_is_true`
+
+The most flexible test -- assert any SQL expression evaluates to true for all rows.
+
+```yaml
+models:
+  - name: fct_orders
+    data_tests:
+      - dbt_utils.expression_is_true:
+          expression: "total_amount >= 0"
+      - dbt_utils.expression_is_true:
+          expression: "order_date <= current_date"
+      - dbt_utils.expression_is_true:
+          expression: "credit_card_amount + bank_transfer_amount = total_amount"
+```
+
+### `recency`
+
+Assert that the most recent record is within an expected time window.
+
+```yaml
+models:
+  - name: fct_orders
+    data_tests:
+      - dbt_utils.recency:
+          datepart: day
+          field: order_date
+          interval: 3
+          # Snowflake: DATEDIFF | BigQuery: DATE_DIFF
+```
+
+---
+
+## Test Configuration
+
+### Severity: `warn` vs `error`
+
+| Severity | Behavior | Use When |
+|----------|----------|----------|
+| `error` (default) | Blocks pipeline | Primary keys, referential integrity, critical business rules |
+| `warn` | Logs warning, continues | Data quality monitoring, statistical checks, soft constraints |
+
+```yaml
+      - name: email
+        data_tests:
+          - unique:
+              severity: warn       # Duplicates are concerning but not blocking
+          - not_null:
+              severity: error      # Missing email on active customer IS blocking
+              where: "is_active = true"
+```
+
+### Tags for Selective Execution
+
+```yaml
+      - name: order_id
+        data_tests:
+          - unique:
+              config:
+                tags: ['primary_key', 'critical']
+      - name: total_amount
+        data_tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+              max_value: 100000
+              config:
+                tags: ['data_quality', 'statistical']
+```
+
+```bash
+dbt test --select tag:critical        # Run only critical tests
+dbt test --select tag:data_quality    # Run only data quality tests
+dbt test --select fct_orders          # Run all tests for a model
+```
+
+### `store_failures` for Debugging
+
+Persist failing rows to a table for inspection.
+
+```yaml
+      - name: customer_id
+        data_tests:
+          - relationships:
+              to: ref('dim_customers')
+              field: customer_id
+              config:
+                store_failures: true
+                # Creates: <schema>_dbt_test__audit.relationships_fct_orders_customer_id
+```
+
+Enable globally:
+
+```yaml
+# dbt_project.yml
+tests:
+  my_project:
+    +store_failures: true
+    +schema: dbt_test_failures
+```
+
+### `limit` to Cap Failure Rows
+
+```yaml
+          - unique:
+              config:
+                store_failures: true
+                limit: 500          # Store at most 500 failing rows
+```
+
+### Per-environment Configuration
+
+```yaml
+# Skip expensive statistical tests in dev
+      - name: total_amount
+        data_tests:
+          - dbt_expectations.expect_column_mean_to_be_between:
+              min_value: 20
+              max_value: 500
+              config:
+                enabled: "{{ target.name != 'dev' }}"
+                tags: ['statistical', 'expensive']
+```
+
+### `+meta` for Test Documentation
+
+```yaml
+      - name: order_id
+        data_tests:
+          - unique:
+              config:
+                meta:
+                  owner: "data-engineering"
+                  sla: "must pass within 15 min of pipeline start"
+                  runbook: "https://wiki.example.com/runbooks/duplicate-orders"
+```
+
+---
+
+## Testing Strategy by Layer
+
+### Decision Matrix
+
+| Layer | Required Tests | Recommended Tests | Optional Tests |
+|-------|---------------|-------------------|----------------|
+| **Sources** | Freshness (`loaded_at_field`) | `not_null` on PKs | `unique` on PKs |
+| **Staging** | `unique` + `not_null` on PK | `accepted_values` on status cols | Relationships to other staging |
+| **Intermediate** | None (tested via downstream) | `unique` + `not_null` if materialized | `expression_is_true` for logic |
+| **Marts (facts)** | `unique` + `not_null` on PK, `not_null` on FKs, `relationships` | `accepted_values`, row count bounds, `recency` | Statistical, cross-table reconciliation |
+| **Marts (dims)** | `unique` + `not_null` on PK | `accepted_values` on type cols, `not_null` on key attrs | Regex on formatted columns |
+
+### Staging Layer: Minimal but Essential
+
+```yaml
+models:
+  - name: stg_stripe__payments
+    columns:
+      - name: payment_id
+        data_tests:
+          - unique                 # Required: PK integrity
+          - not_null               # Required: PK integrity
+      - name: payment_status
+        data_tests:
+          - accepted_values:       # Recommended: catch schema drift
+              values: ['completed', 'pending', 'failed', 'refunded']
+```
+
+### Intermediate Layer: Tested Indirectly
+
+Intermediate models use `ephemeral` materialization by default. They are inlined as CTEs and tested through downstream mart models. Add direct tests only when materialized as a view or table.
+
+### Marts Layer: Full Coverage
+
+```yaml
+models:
+  - name: fct_orders
+    data_tests:
+      - dbt_expectations.expect_table_row_count_to_be_between:
+          min_value: 1000
+          max_value: 10000000
+      - dbt_utils.recency:
+          datepart: day
+          field: order_date
+          interval: 3
+          severity: warn
+    columns:
+      - name: order_id
+        data_tests:
+          - unique
+          - not_null
+      - name: customer_id
+        data_tests:
+          - not_null
+          - relationships:
+              to: ref('dim_customers')
+              field: customer_id
+      - name: order_status
+        data_tests:
+          - accepted_values:
+              values: ['completed', 'pending', 'cancelled', 'refunded']
+      - name: total_amount
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+              max_value: 100000
+      - name: order_date
+        data_tests:
+          - not_null
+
+  - name: dim_customers
+    columns:
+      - name: customer_id
+        data_tests:
+          - unique
+          - not_null
+      - name: email
+        data_tests:
+          - unique:
+              severity: warn
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: "^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$"
+              severity: warn
+```
+
+---
+
+## Anti-patterns
+
+### 1. Over-testing Staging
+
+```yaml
+# DON'T: Exhaustive tests on staging models
+models:
+  - name: stg_stripe__payments
+    data_tests:
+      - dbt_expectations.expect_table_row_count_to_be_between:
+          min_value: 1000
+          max_value: 10000000
+    columns:
+      - name: amount_dollars
+        data_tests:
+          - dbt_expectations.expect_column_mean_to_be_between:
+              min_value: 10
+              max_value: 500
+```
+
+```yaml
+# DO: Keep staging tests focused on PK integrity — test business rules in marts
+models:
+  - name: stg_stripe__payments
+    columns:
+      - name: payment_id
+        data_tests:
+          - unique
+          - not_null
+```
+
+**Why:** Staging is a thin cleaning layer. Row count checks and statistical tests belong on marts where data is consumed.
+
+### 2. Skipping Mart Tests
+
+```yaml
+# DON'T: Assume upstream tests are sufficient
+models:
+  - name: fct_orders
+    columns:
+      - name: order_id
+        # "It's already tested in staging" — no tests here
+```
+
+```yaml
+# DO: Test independently — joins introduce duplicates and nulls
+models:
+  - name: fct_orders
+    columns:
+      - name: order_id
+        data_tests:
+          - unique       # LEFT JOIN can duplicate rows
+          - not_null
+      - name: total_amount
+        data_tests:
+          - not_null     # LEFT JOIN can introduce NULLs
+```
+
+**Why:** Joins change data guarantees. A LEFT JOIN introduces NULLs; a many-to-many join creates duplicates. Always re-test at the mart layer.
+
+### 3. Testing Warehouse Functions
+
+```sql
+-- DON'T: Test that Snowflake/BigQuery functions work correctly
+-- tests/assert_datediff_works.sql
+select 1 where datediff('day', '2024-01-01', '2024-01-02') != 1
+```
+
+**Why:** Trust the warehouse engine. Test your transformations and business logic, not built-in functions.
+
+### 4. Ignoring Failures / All Warnings
+
+```yaml
+# DON'T: Set everything to warn to avoid pipeline failures
+      - name: order_id
+        data_tests:
+          - unique:
+              severity: warn       # Should be error — PK violations are critical
+```
+
+```yaml
+# DO: Reserve warn for soft constraints, error for hard constraints
+      - name: order_id
+        data_tests:
+          - unique:
+              severity: error      # Hard constraint — pipeline must stop
+      - name: email
+        data_tests:
+          - unique:
+              severity: warn       # Soft constraint — investigate, don't block
+```
+
+**Why:** When everything is a warning, nothing is a warning. Use `error` for anything that produces incorrect analytics if ignored.
+
+### 5. Not Using `store_failures` When Debugging
+
+```bash
+# DON'T: Stare at "Got 47 results, configured to fail if != 0" with no context
+dbt test --select fct_orders
+```
+
+```yaml
+# DO: Enable store_failures to inspect actual failing rows
+      - name: order_id
+        data_tests:
+          - unique:
+              config:
+                store_failures: true
+```
+
+```sql
+-- Then query the failure table:
+select * from dbt_test_failures.unique_fct_orders_order_id limit 100;
+```
+
+**Why:** Without `store_failures`, debugging requires re-running test queries manually. With it, failing rows are persisted for immediate inspection.
+
+---
+
+**Back to:** [Main Skill File](../SKILL.md)


### PR DESCRIPTION
## Summary
- Add comprehensive dbt (data build tool) skill at `skills/dbt-skill/`
- Core `SKILL.md` (523 lines) covers project structure, Medallion+Kimball modeling, naming conventions, SQL style guide, materializations, source config, testing overview, and commands cheat sheet
- 6 progressive disclosure reference files (684-1,217 lines each) covering testing/quality, CI/CD, Jinja/macros/packages, incremental/performance, data quality/observability, and semantic layer/governance
- Targets Snowflake and BigQuery as primary warehouses
- Follows the standalone skill pattern established by `skills/terraform-skill/`

## Files Added (8)
| File | Lines | Purpose |
|------|-------|---------|
| `SKILL.md` | 523 | Core skill — activates on dbt tasks |
| `README.md` | 140 | GitHub/marketplace documentation |
| `references/testing-quality.md` | 888 | Schema, generic, singular, unit tests |
| `references/ci-cd-deployment.md` | 684 | GitHub Actions, Slim CI, dbt Cloud |
| `references/jinja-macros-packages.md` | 1,217 | Jinja, macros, 7 essential packages |
| `references/incremental-performance.md` | 1,212 | Microbatch, merge, perf tuning |
| `references/data-quality-observability.md` | 744 | Freshness, Elementary, alerting |
| `references/semantic-layer-governance.md` | 696 | MetricFlow, contracts, dbt Mesh |

## Test plan
- [ ] Verify skill appears in Claude Code skills list
- [ ] Test activation with a dbt-related prompt (e.g., "Create a dbt project")
- [ ] Verify cross-file links resolve correctly
- [ ] Spot-check code examples for SQL/YAML/Jinja syntax correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)