### PR TITLE
fix(council): tolerate JSON-stringified args in workflow templates

### DIFF
--- a/commands/_council-engine.md
+++ b/commands/_council-engine.md
@@ -686,7 +686,7 @@ After spawning agents but before deliberation, load relevant skills for each age
 
 Run the full R1 → pairing → R2 → R3 → synthesis loop as a background Workflow so round texts never enter the conductor's context.
 
-1. Read the canonical script at `~/.claude/skills/council/references/workflows/council-deliberation.template.js` and invoke the **Workflow tool** with that script verbatim (everything session-specific flows through `args` — substitute nothing in the script body):
+1. Read the canonical script at `~/.claude/skills/council/references/workflows/council-deliberation.template.js` and invoke the **Workflow tool** with that script verbatim (everything session-specific flows through `args` — substitute nothing in the script body). Pass `args` as an **actual JSON object** in the tool call, never a JSON-encoded string — a stringified payload reaches the script as one string and the contract guard throws `requires args: sessionDir, idea, roster[]`:
 
    ```
    args:

--- a/skills/council/references/workflows/council-audit.template.js
+++ b/skills/council/references/workflows/council-audit.template.js
@@ -26,11 +26,16 @@ export const meta = {
   ],
 }
 
+// Tolerate a JSON-stringified args payload: LLM callers sometimes serialize the
+// object before handing it to the Workflow tool. Parse it back to an object so
+// the contract guard checks real values, not undefined keys off a string.
+const _args = typeof args === 'string' ? JSON.parse(args) : (args || {})
+
 const {
   sessionDir, workspace,
   zones = [], criteria = '', auditModel = 'sonnet',
   maxPasses = 5, contextBlock = '',
-} = args || {}
+} = _args
 
 if (!sessionDir || !workspace || zones.length === 0) {
   throw new Error('council-audit requires args: sessionDir, workspace, zones[]')

--- a/skills/council/references/workflows/council-deliberation.template.js
+++ b/skills/council/references/workflows/council-deliberation.template.js
@@ -29,12 +29,17 @@ export const meta = {
   ],
 }
 
+// Tolerate a JSON-stringified args payload: LLM callers sometimes serialize the
+// object before handing it to the Workflow tool. Parse it back to an object so
+// the contract guard checks real values, not undefined keys off a string.
+const _args = typeof args === 'string' ? JSON.parse(args) : (args || {})
+
 const {
   sessionDir, workspace, idea,
   contextBlock = '', interviewTranscript = '', pairingRules = 'organic',
   roster = [], rounds = 3, maxPairs = 4,
   challengeModel = null, guidedFeedback = null, startAtRound = 1,
-} = args || {}
+} = _args
 
 if (!sessionDir || !idea || !Array.isArray(roster) || roster.length === 0) {
   throw new Error('council-deliberation requires args: sessionDir, idea, roster[]')


### PR DESCRIPTION
## Summary

A council deliberation Workflow run failed with `council-deliberation requires args: sessionDir, idea, roster[]` on an otherwise valid invocation. Root cause: the LLM conductor serialized the Workflow `args` object to a JSON **string** before the tool call. Destructuring named keys off a string yields `undefined`, so the contract guard threw.

This hardens both layers against that recurring LLM-caller failure mode.

## Changes

- **`council-deliberation.template.js`** / **`council-audit.template.js`**: parse a stringified payload back to an object (`typeof args === 'string' ? JSON.parse(args) : (args || {})`) before the contract guard runs. Both templates shared the identical `args || {}` pattern and the same latent bug.
- **`commands/_council-engine.md`**: tighten the caller instruction to require `args` as an actual JSON object, naming the exact error a stringified payload produces.

## Verification

- `node --check` passes on both edited templates.
- Pre-commit hooks (secret scan, commit-msg) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)